### PR TITLE
Add delete() function to FhirClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,7 @@
-# python-package-template
-Cookiecutter template for creating a new Python Package
+## Configuring Dev Environment
 
-# Usage
-Install cookiecutter:
+Run `make init` to configure dev environment
 
-`pip install -U cookiecutter`
+## Tests
 
-Run cookiecutter:
-
-`cookiecutter -f https://github.com/imranq2/python-package-template.git -o ../`
-
-This will ask you for the parameters.
-
-Alternatively, create a cookiecutter.json
-{
-    "directory_name": "Hello",
-    "package_name": "Howdy",
-    "author": "Julie",
-    "author_email": "foo@email.com",
-    "package_description": "description",
-    "package_github_url": "url",
-
-}
-
-After generation is complete, run `make init` to set up your environment.
+Run `make tests` to run all tests.

--- a/tests/test_fhir_client_patient_delete.py
+++ b/tests/test_fhir_client_patient_delete.py
@@ -1,0 +1,31 @@
+from typing import Any, Optional
+
+import requests
+import requests_mock
+from requests import Response
+
+from helix_fhir_client_sdk.fhir_client import FhirClient
+
+
+def test_fhir_client_patient_delete() -> None:
+    with requests_mock.Mocker() as mock:
+        # Arrange
+        url = "http://foo"
+
+        def delete_matcher(request: Any) -> Optional[Response]:
+            if request.path == "/patient/12345":
+                resp: Response = requests.Response()
+                resp.status_code = 204
+                return resp
+            return None
+
+        mock.add_matcher(delete_matcher)
+
+        # Act
+        fhir_client = FhirClient()
+        fhir_client = fhir_client.url(url).resource("Patient").id_("12345")
+        response: Response = fhir_client.delete()
+
+        # Assert
+        response.raise_for_status()
+        assert response.status_code == 204


### PR DESCRIPTION
Because delete only accepts single IDs, I decided against creating a specific FhirDeleteResponse type, but now I'm questioning that decision, so design feedback around that decision would be particularly helpful.