### PR TITLE
Skip calls in graph if scope does not include the resources

### DIFF
--- a/helix_fhir_client_sdk/fhir_client.py
+++ b/helix_fhir_client_sdk/fhir_client.py
@@ -2678,4 +2678,5 @@ class FhirClient(SimulatedGraphProcessorMixin):
             url=self._url,
             expand_fhir_bundle=self._expand_fhir_bundle,
             logger=self._logger,
+            auth_scopes=self._auth_scopes,
         )

--- a/helix_fhir_client_sdk/utilities/fhir_scope_parser.py
+++ b/helix_fhir_client_sdk/utilities/fhir_scope_parser.py
@@ -79,6 +79,10 @@ class FhirScopeParser:
         if not self.parsed_scopes:
             return True
 
+        # check if this is a valid SMART on FHIR scope
+        if not any([s for s in self.parsed_scopes if s.resource_type == "launch"]):
+            return True
+
         assert resource_type
         assert interaction
 

--- a/helix_fhir_client_sdk/utilities/fhir_scope_parser.py
+++ b/helix_fhir_client_sdk/utilities/fhir_scope_parser.py
@@ -6,6 +6,12 @@ from helix_fhir_client_sdk.utilities.fhir_scope_parser_result import (
 
 
 class FhirScopeParser:
+    def __init__(self, scopes: Optional[str]) -> None:
+        self.scopes = scopes
+        self.parsed_scopes: Optional[List[FhirScopeParserResult]] = (
+            self.parse_scopes(scopes) if scopes else None
+        )
+
     @staticmethod
     def parse_scopes(scopes: Optional[str]) -> List[FhirScopeParserResult]:
         if not scopes:
@@ -44,3 +50,37 @@ class FhirScopeParser:
                 )
 
         return parsed_scopes
+
+    def scope_allows(self, resource_type: str, interaction: str = "read") -> bool:
+        """
+        Returns whether the scope allows the given resource type and interaction.
+
+
+        :param resource_type: The resource type to check.
+        :param interaction: The interaction to check.
+        :return: True if the scope allows the given resource type and interaction, False otherwise.
+        """
+        if not self.parsed_scopes:
+            return True
+        assert resource_type
+        assert interaction
+
+        # note that resource_type is actually called Operation in SMART on FHIR scopes:
+        # A SMART on FHIR scope string is constructed as resourceType.operation.permission.
+        # For example, the scope string patient/*.read requests read-only access to all patient-related resources.
+        scope: FhirScopeParserResult
+        for scope in self.parsed_scopes:
+            if (
+                scope.operation
+                and scope.interaction
+                and (
+                    scope.operation == "*"
+                    or scope.operation.lower() == resource_type.lower()
+                )
+                and (
+                    scope.interaction == "*"
+                    or scope.interaction.lower() == interaction.lower()
+                )
+            ):
+                return True
+        return False

--- a/helix_fhir_client_sdk/utilities/fhir_scope_parser.py
+++ b/helix_fhir_client_sdk/utilities/fhir_scope_parser.py
@@ -6,10 +6,12 @@ from helix_fhir_client_sdk.utilities.fhir_scope_parser_result import (
 
 
 class FhirScopeParser:
-    def __init__(self, scopes: Optional[str]) -> None:
-        self.scopes = scopes
+    def __init__(self, scopes: Optional[List[str]]) -> None:
+        self.scopes: Optional[List[str]] = scopes
         self.parsed_scopes: Optional[List[FhirScopeParserResult]] = (
-            self.parse_scopes(scopes) if scopes else None
+            self.parse_scopes(" ".join([s for s in scopes if s]))
+            if scopes and len([s for s in scopes if s])
+            else None
         )
 
     @staticmethod

--- a/helix_fhir_client_sdk/utilities/fhir_scope_parser.py
+++ b/helix_fhir_client_sdk/utilities/fhir_scope_parser.py
@@ -1,0 +1,46 @@
+from typing import Optional, List
+
+from helix_fhir_client_sdk.utilities.fhir_scope_parser_result import (
+    FhirScopeParserResult,
+)
+
+
+class FhirScopeParser:
+    @staticmethod
+    def parse_scopes(scopes: Optional[str]) -> List[FhirScopeParserResult]:
+        if not scopes:
+            return []
+        parsed_scopes: List[FhirScopeParserResult] = []
+        scope_list = scopes.split(" ")
+
+        for scope in scope_list:
+            if "/" in scope:
+                resource, interaction = scope.split("/")
+                if "." in interaction:
+                    operation, permission = interaction.split(".")
+                    parsed_scopes.append(
+                        FhirScopeParserResult(
+                            resource_type=resource.strip(" \n") if resource else None,
+                            operation=operation.strip(" \n") if operation else None,
+                            interaction=permission.strip(" \n").lower()
+                            if permission
+                            else None,
+                        )
+                    )
+                else:
+                    parsed_scopes.append(
+                        FhirScopeParserResult(
+                            resource_type=resource.strip(" \n") if resource else None,
+                            interaction=interaction.strip(" \n").lower()
+                            if interaction
+                            else None,
+                        )
+                    )
+            elif scope and scope.strip(" \n") != "":
+                parsed_scopes.append(
+                    FhirScopeParserResult(
+                        scope=scope,
+                    )
+                )
+
+        return parsed_scopes

--- a/helix_fhir_client_sdk/utilities/fhir_scope_parser.py
+++ b/helix_fhir_client_sdk/utilities/fhir_scope_parser.py
@@ -7,6 +7,12 @@ from helix_fhir_client_sdk.utilities.fhir_scope_parser_result import (
 
 class FhirScopeParser:
     def __init__(self, scopes: Optional[List[str]]) -> None:
+        """
+        This class parses SMART on FHIR scopes and can answer whether a resource is allowed to be downloaded
+        https://build.fhir.org/ig/HL7/smart-app-launch/scopes-and-launch-context.html
+
+        :param scopes: The scopes to parse.
+        """
         self.scopes: Optional[List[str]] = scopes
         self.parsed_scopes: Optional[List[FhirScopeParserResult]] = (
             self.parse_scopes(" ".join([s for s in scopes if s]))
@@ -16,6 +22,12 @@ class FhirScopeParser:
 
     @staticmethod
     def parse_scopes(scopes: Optional[str]) -> List[FhirScopeParserResult]:
+        """
+        Parses the given scopes into a list of FhirScopeParserResult objects.
+
+        :param scopes: The scopes to parse.
+        :return: A list of FhirScopeParserResult objects.
+        """
         if not scopes:
             return []
         parsed_scopes: List[FhirScopeParserResult] = []
@@ -62,8 +74,11 @@ class FhirScopeParser:
         :param interaction: The interaction to check.
         :return: True if the scope allows the given resource type and interaction, False otherwise.
         """
+
+        # if there are no scopes then allow everything
         if not self.parsed_scopes:
             return True
+
         assert resource_type
         assert interaction
 

--- a/helix_fhir_client_sdk/utilities/fhir_scope_parser_result.py
+++ b/helix_fhir_client_sdk/utilities/fhir_scope_parser_result.py
@@ -1,0 +1,10 @@
+import dataclasses
+from typing import Optional
+
+
+@dataclasses.dataclass
+class FhirScopeParserResult:
+    resource_type: Optional[str] = None
+    operation: Optional[str] = None
+    interaction: Optional[str] = None
+    scope: Optional[str] = None

--- a/helix_fhir_client_sdk/utilities/fhir_scope_parser_result.py
+++ b/helix_fhir_client_sdk/utilities/fhir_scope_parser_result.py
@@ -4,6 +4,12 @@ from typing import Optional
 
 @dataclasses.dataclass
 class FhirScopeParserResult:
+    """
+    This class stores the result from parsing a scope per:
+    https://build.fhir.org/ig/HL7/smart-app-launch/scopes-and-launch-context.html
+
+    """
+
     resource_type: Optional[str] = None
     operation: Optional[str] = None
     interaction: Optional[str] = None

--- a/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser.py
+++ b/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser.py
@@ -1,0 +1,139 @@
+from typing import List
+
+from helix_fhir_client_sdk.utilities.fhir_scope_parser import FhirScopeParser
+from helix_fhir_client_sdk.utilities.fhir_scope_parser_result import (
+    FhirScopeParserResult,
+)
+
+
+def test_fhir_scope_parser() -> None:
+    scope_parser_result: List[FhirScopeParserResult] = FhirScopeParser.parse_scopes(
+        scopes="""
+patient/AllergyIntolerance.read patient/Binary.read patient/CarePlan.read patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/Medication.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read patient/Procedure.read patient/Provenance.read patient/RelatedPerson.Read launch/patient        
+        """
+    )
+    assert scope_parser_result == [
+        FhirScopeParserResult(
+            resource_type="patient",
+            operation="AllergyIntolerance",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="patient", operation="Binary", interaction="read", scope=None
+        ),
+        FhirScopeParserResult(
+            resource_type="patient",
+            operation="CarePlan",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="patient",
+            operation="CareTeam",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="patient",
+            operation="Condition",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="patient", operation="Device", interaction="read", scope=None
+        ),
+        FhirScopeParserResult(
+            resource_type="patient",
+            operation="DiagnosticReport",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="patient",
+            operation="DocumentReference",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="patient",
+            operation="Encounter",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="patient", operation="Goal", interaction="read", scope=None
+        ),
+        FhirScopeParserResult(
+            resource_type="patient",
+            operation="Immunization",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="patient",
+            operation="Location",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="patient",
+            operation="Medication",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="patient",
+            operation="MedicationRequest",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="patient",
+            operation="Observation",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="patient",
+            operation="Organization",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="patient", operation="Patient", interaction="read", scope=None
+        ),
+        FhirScopeParserResult(
+            resource_type="patient",
+            operation="Practitioner",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="patient",
+            operation="PractitionerRole",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="patient",
+            operation="Procedure",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="patient",
+            operation="Provenance",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="patient",
+            operation="RelatedPerson",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="launch", operation=None, interaction="patient", scope=None
+        ),
+    ]

--- a/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser_can_parse_scopes.py
+++ b/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser_can_parse_scopes.py
@@ -6,7 +6,7 @@ from helix_fhir_client_sdk.utilities.fhir_scope_parser_result import (
 )
 
 
-def test_fhir_scope_parser() -> None:
+def test_fhir_scope_parser_can_parse_scopes() -> None:
     scope_parser_result: List[FhirScopeParserResult] = FhirScopeParser.parse_scopes(
         scopes="""
 patient/AllergyIntolerance.read patient/Binary.read patient/CarePlan.read patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/Medication.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read patient/Procedure.read patient/Provenance.read patient/RelatedPerson.Read launch/patient        

--- a/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser_correct_allow.py
+++ b/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser_correct_allow.py
@@ -1,0 +1,28 @@
+from helix_fhir_client_sdk.utilities.fhir_scope_parser import FhirScopeParser
+
+
+def test_fhir_scope_parser_correct_allow() -> None:
+    scope_parser: FhirScopeParser = FhirScopeParser(
+        scopes="""
+patient/AllergyIntolerance.read patient/Binary.read patient/CarePlan.read patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/Medication.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read patient/Procedure.read patient/Provenance.read patient/RelatedPerson.Read launch/patient        
+        """
+    )
+
+    assert (
+        scope_parser.scope_allows(resource_type="Patient", interaction="read") is True
+    )
+
+    assert (
+        scope_parser.scope_allows(resource_type="Condition", interaction="read") is True
+    )
+
+    assert (
+        scope_parser.scope_allows(
+            resource_type="MedicationDispense", interaction="read"
+        )
+        is False
+    )
+
+    assert (
+        scope_parser.scope_allows(resource_type="Patient", interaction="write") is False
+    )

--- a/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser_correct_allow.py
+++ b/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser_correct_allow.py
@@ -3,9 +3,11 @@ from helix_fhir_client_sdk.utilities.fhir_scope_parser import FhirScopeParser
 
 def test_fhir_scope_parser_correct_allow() -> None:
     scope_parser: FhirScopeParser = FhirScopeParser(
-        scopes="""
+        scopes=[
+            """
 patient/AllergyIntolerance.read patient/Binary.read patient/CarePlan.read patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/Medication.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read patient/Procedure.read patient/Provenance.read patient/RelatedPerson.Read launch/patient        
         """
+        ]
     )
 
     assert (

--- a/tests/async/simulated_graph/test_fhir_simulated_graph_caching_scope_parser_async.py
+++ b/tests/async/simulated_graph/test_fhir_simulated_graph_caching_scope_parser_async.py
@@ -139,7 +139,7 @@ async def test_fhir_simulated_graph_caching_scope_parser_async() -> None:
     fhir_client = fhir_client.expand_fhir_bundle(False)
     fhir_client.logger(logger=logger)
     fhir_client.auth_scopes(
-        # include other resources but skip Observation
+        # include other resources but skip Observation and Encounter
         auth_scopes=[
             "patient/Patient.read",
             "patient/AllergyIntolerance.read",

--- a/tests/async/simulated_graph/test_fhir_simulated_graph_caching_scope_parser_async.py
+++ b/tests/async/simulated_graph/test_fhir_simulated_graph_caching_scope_parser_async.py
@@ -145,6 +145,7 @@ async def test_fhir_simulated_graph_caching_scope_parser_async() -> None:
             "patient/AllergyIntolerance.read",
             "patient/Practitioner.read patient/Organization.read",
             "patient/Coverage.read",
+            "launch/patient",
         ]
     )
 

--- a/tests/async/simulated_graph/test_fhir_simulated_graph_caching_scope_parser_async.py
+++ b/tests/async/simulated_graph/test_fhir_simulated_graph_caching_scope_parser_async.py
@@ -1,0 +1,213 @@
+import json
+from pathlib import Path
+from typing import Dict, Any
+
+from mockserver_client.mockserver_client import (
+    MockServerFriendlyClient,
+    mock_request,
+    mock_response,
+    times,
+)
+
+from helix_fhir_client_sdk.fhir_client import FhirClient
+
+from helix_fhir_client_sdk.responses.fhir_get_response import FhirGetResponse
+from tests.test_logger import TestLogger
+
+
+async def test_fhir_simulated_graph_caching_scope_parser_async() -> None:
+    print("")
+    data_dir: Path = Path(__file__).parent.joinpath("./")
+    graph_json: Dict[str, Any]
+    with open(data_dir.joinpath("graphs").joinpath("provider.json"), "r") as file:
+        contents = file.read()
+        graph_json = json.loads(contents)
+
+    test_name = "test_fhir_simulated_graph_caching_scope_parser_async"
+
+    mock_server_url = "http://mock-server:1080"
+    mock_client: MockServerFriendlyClient = MockServerFriendlyClient(
+        base_url=mock_server_url
+    )
+
+    relative_url: str = test_name
+    absolute_url: str = mock_server_url + "/" + test_name
+
+    mock_client.clear(f"/{test_name}/*.*")
+    mock_client.reset()
+
+    response_text = {
+        "resourceType": "Patient",
+        "id": "1",
+        "generalPractitioner": [{"reference": "Practitioner/5"}],
+        "managingOrganization": {"reference": "Organization/6"},
+    }
+
+    mock_client.expect(
+        mock_request(path=f"/{relative_url}/Patient/1", method="GET"),
+        mock_response(body=response_text),
+        timing=times(1),
+    )
+
+    response_text = {"resourceType": "Practitioner", "id": "5"}
+    mock_client.expect(
+        mock_request(path=f"/{relative_url}/Practitioner/5", method="GET"),
+        mock_response(body=response_text),
+        timing=times(1),
+    )
+
+    response_text = {"resourceType": "Organization", "id": "6"}
+    mock_client.expect(
+        mock_request(path=f"/{relative_url}/Organization/6", method="GET"),
+        mock_response(body=response_text),
+        timing=times(1),
+    )
+
+    response_text = {"entry": [{"resource": {"resourceType": "Coverage", "id": "7"}}]}
+    mock_client.expect(
+        mock_request(
+            path=f"/{relative_url}/Coverage",
+            querystring={"patient": "1"},
+            method="GET",
+        ),
+        mock_response(body=response_text),
+        timing=times(1),
+    )
+
+    response_text = {
+        "entry": [{"resource": {"resourceType": "Observation", "id": "8"}}]
+    }
+    mock_client.expect(
+        mock_request(
+            path=f"/{relative_url}/Observation",
+            querystring={
+                "patient": "1",
+                "category": "vital-signs,social-history,laboratory",
+            },
+            method="GET",
+        ),
+        mock_response(body=response_text),
+        timing=times(1),
+    )
+
+    response_text = {
+        "entry": [
+            {
+                "resource": {
+                    "resourceType": "Encounter",
+                    "id": "8",
+                    "participant": [
+                        {"individual": {"reference": "Practitioner/12345"}}
+                    ],
+                }
+            },
+            {
+                "resource": {
+                    "resourceType": "Encounter",
+                    "id": "10",
+                    "participant": [
+                        {"individual": {"reference": "Practitioner/12345"}}
+                    ],
+                }
+            },
+        ]
+    }
+    mock_client.expect(
+        mock_request(
+            path=f"/{relative_url}/Encounter",
+            querystring={"patient": "1"},
+            method="GET",
+        ),
+        mock_response(body=response_text),
+        timing=times(1),
+    )
+
+    response_text = {
+        "entry": [{"resource": {"resourceType": "Practitioner", "id": "12345"}}]
+    }
+    mock_client.expect(
+        mock_request(
+            path=f"/{relative_url}/Practitioner/12345",
+            method="GET",
+        ),
+        mock_response(body=response_text),
+        timing=times(1),
+    )
+
+    logger = TestLogger()
+    fhir_client = FhirClient()
+    fhir_client = fhir_client.expand_fhir_bundle(False)
+    fhir_client.logger(logger=logger)
+    fhir_client.auth_scopes(
+        # include other resources but skip Observation
+        auth_scopes=[
+            "patient/Patient.read",
+            "patient/AllergyIntolerance.read",
+            "patient/Practitioner.read patient/Organization.read",
+            "patient/Coverage.read",
+        ]
+    )
+
+    fhir_client.extra_context_to_return({"service_slug": "medstar"})
+
+    auth_access_token = "my_access_token"
+    if auth_access_token:
+        fhir_client = fhir_client.set_access_token(auth_access_token)
+
+    fhir_client = fhir_client.url(absolute_url).resource("Patient")
+    response: FhirGetResponse = await fhir_client.simulate_graph_async(
+        id_="1",
+        graph_json=graph_json,
+        contained=False,
+        separate_bundle_resources=False,
+    )
+    print(response.responses)
+
+    expected_json = {
+        "entry": [
+            {
+                "request": {
+                    "method": "GET",
+                    "url": "http://mock-server:1080/test_fhir_simulated_graph_caching_scope_parser_async/Patient/1",
+                },
+                "resource": {
+                    "generalPractitioner": [{"reference": "Practitioner/5"}],
+                    "id": "1",
+                    "managingOrganization": {"reference": "Organization/6"},
+                    "resourceType": "Patient",
+                },
+                "response": {"status": "200"},
+            },
+            {
+                "request": {
+                    "method": "GET",
+                    "url": "http://mock-server:1080/test_fhir_simulated_graph_caching_scope_parser_async/Practitioner/5",
+                },
+                "resource": {"id": "5", "resourceType": "Practitioner"},
+                "response": {"status": "200"},
+            },
+            {
+                "request": {
+                    "method": "GET",
+                    "url": "http://mock-server:1080/test_fhir_simulated_graph_caching_scope_parser_async/Organization/6",
+                },
+                "resource": {"id": "6", "resourceType": "Organization"},
+                "response": {"status": "200"},
+            },
+        ]
+    }
+
+    bundle: Dict[str, Any]
+    try:
+        bundle = json.loads(response.responses)
+    except Exception as e:
+        raise Exception(
+            f"Unable to parse result json: {e}: {response.responses}"
+        ) from e
+
+    bundle["entry"] = [
+        e
+        for e in bundle["entry"]
+        if e["resource"]["resourceType"] != "OperationOutcome"
+    ]
+    assert bundle == expected_json


### PR DESCRIPTION
This PR adds intelligence to our code to download graph from PROA server by skipping resources that are not allowed in the SMART on FHIR scopes.