### PR TITLE
IOP-1415-no-patient-read-scope-logs

### DIFF
--- a/helix_fhir_client_sdk/utilities/fhir_scope_parser.py
+++ b/helix_fhir_client_sdk/utilities/fhir_scope_parser.py
@@ -119,17 +119,6 @@ class FhirScopeParser:
                     )
                 ]
 
-        # log warning in event that parsed_scopes does not include a scope that allows patient demographics to be read
-        if not any(
-            [
-                demographic_scope in parsed_scopes
-                for demographic_scope in self._get_patient_demographic_read_scopes()
-            ]
-        ):
-            self.logger.warning(
-                f"Missing patient demographic read scopes in: {scope_list}"
-            )
-
         return parsed_scopes
 
     def scope_allows(self, resource_type: str, interaction: str = "read") -> bool:

--- a/helix_fhir_client_sdk/utilities/fhir_scope_parser.py
+++ b/helix_fhir_client_sdk/utilities/fhir_scope_parser.py
@@ -146,7 +146,9 @@ class FhirScopeParser:
             return True
 
         # check if this is a valid SMART on FHIR scope
-        if not any([s for s in self.parsed_scopes if s.resource_type == "patient"]):
+        if (
+            not any([s for s in self.parsed_scopes if s.resource_type == "patient"])
+        ) and (not any([s for s in self.parsed_scopes if s.resource_type == "user"])):
             return True
 
         # These resources are always allowed

--- a/helix_fhir_client_sdk/utilities/fhir_scope_parser.py
+++ b/helix_fhir_client_sdk/utilities/fhir_scope_parser.py
@@ -78,6 +78,17 @@ class FhirScopeParser:
                     )
                 )
 
+        # ensure launch/patient scope only included if patient/xxx scopes are also present
+        if FhirScopeParserResult(resource_type='launch', operation=None, interaction='patient',
+                                 scope=None) in parsed_scopes:
+            if not any([scope for scope in parsed_scopes if scope.resource_type == "patient"]):
+                self.logger.warning(
+                    "No corresponding 'patient/xxx' scope detected for 'launch/patient', removing 'launch/patient'")
+                parsed_scopes = [scope for scope in parsed_scopes if
+                                 scope != FhirScopeParserResult(resource_type='launch', operation=None,
+                                                                interaction='patient',
+                                                                scope=None)]
+
         # log warning in event that parsed_scopes does not include a scope that allows patient demographics to be read
         if not any([demographic_scope in parsed_scopes for demographic_scope in
                     self._get_patient_demographic_read_scopes()]):
@@ -115,16 +126,16 @@ class FhirScopeParser:
         scope: FhirScopeParserResult
         for scope in self.parsed_scopes:
             if (
-                scope.operation
-                and scope.interaction
-                and (
+                    scope.operation
+                    and scope.interaction
+                    and (
                     scope.operation == "*"
                     or scope.operation.lower() == resource_type.lower()
-                )
-                and (
+            )
+                    and (
                     scope.interaction == "*"
                     or scope.interaction.lower() == interaction.lower()
-                )
+            )
             ):
                 return True
         return False

--- a/helix_fhir_client_sdk/utilities/fhir_scope_parser.py
+++ b/helix_fhir_client_sdk/utilities/fhir_scope_parser.py
@@ -29,12 +29,25 @@ class FhirScopeParser:
 
         :return: A list of FhirScopeParserResult objects that allow patient demographics to be read
         """
-        patient_patient_read = FhirScopeParserResult(resource_type="patient", operation="Patient", interaction="read")
-        patient_star_read = FhirScopeParserResult(resource_type="Patient", operation="*", interaction="read")
-        user_patient_read = FhirScopeParserResult(resource_type="user", operation="Patient", interaction="read")
-        user_star_read = FhirScopeParserResult(resource_type="user", operation="*", interaction="read")
+        patient_patient_read = FhirScopeParserResult(
+            resource_type="patient", operation="Patient", interaction="read"
+        )
+        patient_star_read = FhirScopeParserResult(
+            resource_type="Patient", operation="*", interaction="read"
+        )
+        user_patient_read = FhirScopeParserResult(
+            resource_type="user", operation="Patient", interaction="read"
+        )
+        user_star_read = FhirScopeParserResult(
+            resource_type="user", operation="*", interaction="read"
+        )
 
-        return [patient_patient_read, patient_star_read, user_patient_read, user_star_read]
+        return [
+            patient_patient_read,
+            patient_star_read,
+            user_patient_read,
+            user_star_read,
+        ]
 
     def parse_scopes(self, scopes: Optional[str]) -> List[FhirScopeParserResult]:
         """
@@ -79,20 +92,43 @@ class FhirScopeParser:
                 )
 
         # ensure launch/patient scope only included if patient/xxx scopes are also present
-        if FhirScopeParserResult(resource_type='launch', operation=None, interaction='patient',
-                                 scope=None) in parsed_scopes:
-            if not any([scope for scope in parsed_scopes if scope.resource_type == "patient"]):
+        if (
+            FhirScopeParserResult(
+                resource_type="launch",
+                operation=None,
+                interaction="patient",
+                scope=None,
+            )
+            in parsed_scopes
+        ):
+            if not any(
+                [scope for scope in parsed_scopes if scope.resource_type == "patient"]
+            ):
                 self.logger.warning(
-                    "No corresponding 'patient/xxx' scope detected for 'launch/patient', removing 'launch/patient'")
-                parsed_scopes = [scope for scope in parsed_scopes if
-                                 scope != FhirScopeParserResult(resource_type='launch', operation=None,
-                                                                interaction='patient',
-                                                                scope=None)]
+                    "No corresponding 'patient/xxx' scope detected for 'launch/patient', removing 'launch/patient'"
+                )
+                parsed_scopes = [
+                    scope
+                    for scope in parsed_scopes
+                    if scope
+                    != FhirScopeParserResult(
+                        resource_type="launch",
+                        operation=None,
+                        interaction="patient",
+                        scope=None,
+                    )
+                ]
 
         # log warning in event that parsed_scopes does not include a scope that allows patient demographics to be read
-        if not any([demographic_scope in parsed_scopes for demographic_scope in
-                    self._get_patient_demographic_read_scopes()]):
-            self.logger.warning(f"Missing patient demographic read scopes in: {scope_list}")
+        if not any(
+            [
+                demographic_scope in parsed_scopes
+                for demographic_scope in self._get_patient_demographic_read_scopes()
+            ]
+        ):
+            self.logger.warning(
+                f"Missing patient demographic read scopes in: {scope_list}"
+            )
 
         return parsed_scopes
 
@@ -126,16 +162,16 @@ class FhirScopeParser:
         scope: FhirScopeParserResult
         for scope in self.parsed_scopes:
             if (
-                    scope.operation
-                    and scope.interaction
-                    and (
+                scope.operation
+                and scope.interaction
+                and (
                     scope.operation == "*"
                     or scope.operation.lower() == resource_type.lower()
-            )
-                    and (
+                )
+                and (
                     scope.interaction == "*"
                     or scope.interaction.lower() == interaction.lower()
-            )
+                )
             ):
                 return True
         return False

--- a/helix_fhir_client_sdk/utilities/fhir_scope_parser.py
+++ b/helix_fhir_client_sdk/utilities/fhir_scope_parser.py
@@ -22,33 +22,6 @@ class FhirScopeParser:
             else None
         )
 
-    @staticmethod
-    def _get_patient_demographic_read_scopes() -> List[FhirScopeParserResult]:
-        """
-        Returns a list of scopes as FhirScopeParserResult objects that allow patient demographics to be read
-
-        :return: A list of FhirScopeParserResult objects that allow patient demographics to be read
-        """
-        patient_patient_read = FhirScopeParserResult(
-            resource_type="patient", operation="Patient", interaction="read"
-        )
-        patient_star_read = FhirScopeParserResult(
-            resource_type="Patient", operation="*", interaction="read"
-        )
-        user_patient_read = FhirScopeParserResult(
-            resource_type="user", operation="Patient", interaction="read"
-        )
-        user_star_read = FhirScopeParserResult(
-            resource_type="user", operation="*", interaction="read"
-        )
-
-        return [
-            patient_patient_read,
-            patient_star_read,
-            user_patient_read,
-            user_star_read,
-        ]
-
     def parse_scopes(self, scopes: Optional[str]) -> List[FhirScopeParserResult]:
         """
         Parses the given scopes into a list of FhirScopeParserResult objects.
@@ -134,10 +107,14 @@ class FhirScopeParser:
         if not self.parsed_scopes:
             return True
 
-        # check if this is a valid SMART on FHIR scope
-        if (
-            not any([s for s in self.parsed_scopes if s.resource_type == "patient"])
-        ) and (not any([s for s in self.parsed_scopes if s.resource_type == "user"])):
+        # default to True if vendor/client/server/etc. not using "patient", "user", or "system" based scopes
+        if not any(
+            [
+                s
+                for s in self.parsed_scopes
+                if s.resource_type in ["patient", "user", "system"]
+            ]
+        ):
             return True
 
         # These resources are always allowed

--- a/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser_can_parse_scopes.py
+++ b/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser_can_parse_scopes.py
@@ -10,9 +10,14 @@ def test_fhir_scope_parser_can_parse_scopes() -> None:
     scope_parser_result: List[FhirScopeParserResult] = FhirScopeParser(
         None
     ).parse_scopes(
-        scopes="""
-patient/AllergyIntolerance.read patient/Binary.read patient/CarePlan.read patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/Medication.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read patient/Procedure.read patient/Provenance.read patient/RelatedPerson.Read launch/patient        
-        """
+        scopes=(
+            "patient/AllergyIntolerance.read patient/Binary.read patient/CarePlan.read patient/CareTeam.read "
+            "patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read "
+            "patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read "
+            "patient/Medication.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read "
+            "patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read patient/Procedure.read "
+            "patient/Provenance.read patient/RelatedPerson.Read launch/patient"
+        )
     )
     assert scope_parser_result == [
         FhirScopeParserResult(
@@ -144,8 +149,12 @@ patient/AllergyIntolerance.read patient/Binary.read patient/CarePlan.read patien
 def test_fhir_scope_parser_remove_invalid_launch_patient() -> None:
     no_patient_scope_parser: FhirScopeParser = FhirScopeParser(
         scopes=[
-            """
-launch/patient offline_access openid profile user/AllergyIntolerance.read user/Appointment.read user/CarePlan.read user/Encounter.read user/Immunization.read user/MedicationAdministration.read user/MedicationRequest.read user/Organization.read user/Practitioner.read user/Schedule.read user/Slot.read"""
+            (
+                "launch/patient offline_access openid profile user/AllergyIntolerance.read user/Appointment.read "
+                "user/CarePlan.read user/Encounter.read user/Immunization.read user/MedicationAdministration.read "
+                "user/MedicationRequest.read user/Organization.read user/Practitioner.read user/Schedule.read "
+                "user/Slot.read"
+            )
         ]
     )
     # list of scopes to validate against, notably excluding parsed "launch/patient"

--- a/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser_can_parse_scopes.py
+++ b/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser_can_parse_scopes.py
@@ -139,3 +139,81 @@ patient/AllergyIntolerance.read patient/Binary.read patient/CarePlan.read patien
             resource_type="launch", operation=None, interaction="patient", scope=None
         ),
     ]
+
+
+def test_fhir_scope_parser_remove_invalid_launch_patient() -> None:
+    no_patient_scope_parser: FhirScopeParser = FhirScopeParser(
+        scopes=[
+            """
+launch/patient offline_access openid profile user/AllergyIntolerance.read user/Appointment.read user/CarePlan.read user/Encounter.read user/Immunization.read user/MedicationAdministration.read user/MedicationRequest.read user/Organization.read user/Practitioner.read user/Schedule.read user/Slot.read"""
+        ]
+    )
+    # list of scopes to validate against, notably excluding parsed "launch/patient"
+    valid_parsed_scopes: List[FhirScopeParserResult] = [
+        FhirScopeParserResult(
+            resource_type=None, operation=None, interaction=None, scope="offline_access"
+        ),
+        FhirScopeParserResult(
+            resource_type=None, operation=None, interaction=None, scope="openid"
+        ),
+        FhirScopeParserResult(
+            resource_type=None, operation=None, interaction=None, scope="profile"
+        ),
+        FhirScopeParserResult(
+            resource_type="user",
+            operation="AllergyIntolerance",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="user",
+            operation="Appointment",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="user", operation="CarePlan", interaction="read", scope=None
+        ),
+        FhirScopeParserResult(
+            resource_type="user", operation="Encounter", interaction="read", scope=None
+        ),
+        FhirScopeParserResult(
+            resource_type="user",
+            operation="Immunization",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="user",
+            operation="MedicationAdministration",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="user",
+            operation="MedicationRequest",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="user",
+            operation="Organization",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="user",
+            operation="Practitioner",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="user", operation="Schedule", interaction="read", scope=None
+        ),
+        FhirScopeParserResult(
+            resource_type="user", operation="Slot", interaction="read", scope=None
+        ),
+    ]
+
+    assert no_patient_scope_parser.parsed_scopes is not None
+    assert no_patient_scope_parser.parsed_scopes == valid_parsed_scopes

--- a/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser_can_parse_scopes.py
+++ b/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser_can_parse_scopes.py
@@ -7,7 +7,9 @@ from helix_fhir_client_sdk.utilities.fhir_scope_parser_result import (
 
 
 def test_fhir_scope_parser_can_parse_scopes() -> None:
-    scope_parser_result: List[FhirScopeParserResult] = FhirScopeParser.parse_scopes(
+    scope_parser_result: List[FhirScopeParserResult] = FhirScopeParser(
+        None
+    ).parse_scopes(
         scopes="""
 patient/AllergyIntolerance.read patient/Binary.read patient/CarePlan.read patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/Medication.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read patient/Procedure.read patient/Provenance.read patient/RelatedPerson.Read launch/patient        
         """

--- a/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser_can_parse_scopes.py
+++ b/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser_can_parse_scopes.py
@@ -1,4 +1,5 @@
-from typing import List
+from pytest import mark
+from typing import List, Optional
 
 from helix_fhir_client_sdk.utilities.fhir_scope_parser import FhirScopeParser
 from helix_fhir_client_sdk.utilities.fhir_scope_parser_result import (
@@ -6,223 +7,339 @@ from helix_fhir_client_sdk.utilities.fhir_scope_parser_result import (
 )
 
 
-def test_fhir_scope_parser_can_parse_scopes() -> None:
-    scope_parser_result: List[FhirScopeParserResult] = FhirScopeParser(
-        None
-    ).parse_scopes(
-        scopes=(
-            "patient/AllergyIntolerance.read patient/Binary.read patient/CarePlan.read patient/CareTeam.read "
-            "patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read "
-            "patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read "
-            "patient/Medication.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read "
-            "patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read patient/Procedure.read "
-            "patient/Provenance.read patient/RelatedPerson.Read launch/patient"
-        )
-    )
-    assert scope_parser_result == [
-        FhirScopeParserResult(
-            resource_type="patient",
-            operation="AllergyIntolerance",
-            interaction="read",
-            scope=None,
+@mark.parametrize(
+    argnames="scopes,expected",
+    argvalues=[
+        (
+            [
+                (
+                    "patient/AllergyIntolerance.read patient/Binary.read patient/CarePlan.read patient/CareTeam.read "
+                    "patient/Condition.read patient/Device.read patient/DiagnosticReport.read "
+                    "patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read "
+                    "patient/Location.read patient/Medication.read patient/MedicationRequest.read "
+                    "patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read "
+                    "patient/PractitionerRole.read patient/Procedure.read patient/Provenance.read "
+                    "patient/RelatedPerson.Read launch/patient"
+                )
+            ],
+            [
+                FhirScopeParserResult(
+                    resource_type="patient",
+                    operation="AllergyIntolerance",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="patient",
+                    operation="Binary",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="patient",
+                    operation="CarePlan",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="patient",
+                    operation="CareTeam",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="patient",
+                    operation="Condition",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="patient",
+                    operation="Device",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="patient",
+                    operation="DiagnosticReport",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="patient",
+                    operation="DocumentReference",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="patient",
+                    operation="Encounter",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="patient",
+                    operation="Goal",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="patient",
+                    operation="Immunization",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="patient",
+                    operation="Location",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="patient",
+                    operation="Medication",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="patient",
+                    operation="MedicationRequest",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="patient",
+                    operation="Observation",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="patient",
+                    operation="Organization",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="patient",
+                    operation="Patient",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="patient",
+                    operation="Practitioner",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="patient",
+                    operation="PractitionerRole",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="patient",
+                    operation="Procedure",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="patient",
+                    operation="Provenance",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="patient",
+                    operation="RelatedPerson",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="launch",
+                    operation=None,
+                    interaction="patient",
+                    scope=None,
+                ),
+            ],
         ),
-        FhirScopeParserResult(
-            resource_type="patient", operation="Binary", interaction="read", scope=None
+        (
+            [
+                (
+                    "launch/patient offline_access openid profile user/AllergyIntolerance.read user/Appointment.read "
+                    "user/CarePlan.read user/Encounter.read user/Immunization.read user/MedicationAdministration.read "
+                    "user/MedicationRequest.read user/Organization.read user/Practitioner.read user/Schedule.read "
+                    "user/Slot.read"
+                )
+            ],
+            [
+                FhirScopeParserResult(
+                    resource_type=None,
+                    operation=None,
+                    interaction=None,
+                    scope="offline_access",
+                ),
+                FhirScopeParserResult(
+                    resource_type=None, operation=None, interaction=None, scope="openid"
+                ),
+                FhirScopeParserResult(
+                    resource_type=None,
+                    operation=None,
+                    interaction=None,
+                    scope="profile",
+                ),
+                FhirScopeParserResult(
+                    resource_type="user",
+                    operation="AllergyIntolerance",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="user",
+                    operation="Appointment",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="user",
+                    operation="CarePlan",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="user",
+                    operation="Encounter",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="user",
+                    operation="Immunization",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="user",
+                    operation="MedicationAdministration",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="user",
+                    operation="MedicationRequest",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="user",
+                    operation="Organization",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="user",
+                    operation="Practitioner",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="user",
+                    operation="Schedule",
+                    interaction="read",
+                    scope=None,
+                ),
+                FhirScopeParserResult(
+                    resource_type="user",
+                    operation="Slot",
+                    interaction="read",
+                    scope=None,
+                ),
+            ],
         ),
-        FhirScopeParserResult(
-            resource_type="patient",
-            operation="CarePlan",
-            interaction="read",
-            scope=None,
+        (
+            ["launch/patient offline_access openid profile system/*.read"],
+            [
+                FhirScopeParserResult(
+                    resource_type=None,
+                    operation=None,
+                    interaction=None,
+                    scope="offline_access",
+                ),
+                FhirScopeParserResult(
+                    resource_type=None, operation=None, interaction=None, scope="openid"
+                ),
+                FhirScopeParserResult(
+                    resource_type=None,
+                    operation=None,
+                    interaction=None,
+                    scope="profile",
+                ),
+                FhirScopeParserResult(
+                    resource_type="system",
+                    operation="*",
+                    interaction="read",
+                    scope=None,
+                ),
+            ],
         ),
-        FhirScopeParserResult(
-            resource_type="patient",
-            operation="CareTeam",
-            interaction="read",
-            scope=None,
+        ([], None),
+    ],
+    ids=["Patient Scopes", "User Scopes", "System Scopes", "Non-Smart on FHIR Scopes"],
+)
+def test_fhir_scope_parser_can_parse_scopes(
+    scopes: List[str], expected: Optional[List[FhirScopeParserResult]]
+) -> None:
+    scope_parser: FhirScopeParser = FhirScopeParser(scopes)
+    if expected is None:
+        assert scope_parser.parsed_scopes is expected
+    else:
+        assert scope_parser.parsed_scopes == expected
+
+
+@mark.parametrize(
+    argnames="scopes,expected",
+    argvalues=[
+        (
+            [
+                (
+                    "launch/patient offline_access openid profile patient/AllergyIntolerance.read "
+                    "patient/Appointment.read patient/CarePlan.read patient/Encounter.read patient/Immunization.read "
+                    "patient/MedicationAdministration.read patient/MedicationRequest.read patient/Organization.read "
+                    "patient/Practitioner.read patient/Schedule.read patient/Slot.read"
+                )
+            ],
+            True,
         ),
-        FhirScopeParserResult(
-            resource_type="patient",
-            operation="Condition",
-            interaction="read",
-            scope=None,
+        (
+            [
+                (
+                    "launch/patient offline_access openid profile user/AllergyIntolerance.read user/Appointment.read "
+                    "user/CarePlan.read user/Encounter.read user/Immunization.read user/MedicationAdministration.read "
+                    "user/MedicationRequest.read user/Organization.read user/Practitioner.read user/Schedule.read "
+                    "user/Slot.read"
+                )
+            ],
+            False,
         ),
-        FhirScopeParserResult(
-            resource_type="patient", operation="Device", interaction="read", scope=None
+        (
+            ["launch/patient offline_access openid profile system/*.read"],
+            False,
         ),
-        FhirScopeParserResult(
-            resource_type="patient",
-            operation="DiagnosticReport",
-            interaction="read",
-            scope=None,
+        (
+            ["launch/patient"],
+            False,
         ),
-        FhirScopeParserResult(
-            resource_type="patient",
-            operation="DocumentReference",
-            interaction="read",
-            scope=None,
-        ),
-        FhirScopeParserResult(
-            resource_type="patient",
-            operation="Encounter",
-            interaction="read",
-            scope=None,
-        ),
-        FhirScopeParserResult(
-            resource_type="patient", operation="Goal", interaction="read", scope=None
-        ),
-        FhirScopeParserResult(
-            resource_type="patient",
-            operation="Immunization",
-            interaction="read",
-            scope=None,
-        ),
-        FhirScopeParserResult(
-            resource_type="patient",
-            operation="Location",
-            interaction="read",
-            scope=None,
-        ),
-        FhirScopeParserResult(
-            resource_type="patient",
-            operation="Medication",
-            interaction="read",
-            scope=None,
-        ),
-        FhirScopeParserResult(
-            resource_type="patient",
-            operation="MedicationRequest",
-            interaction="read",
-            scope=None,
-        ),
-        FhirScopeParserResult(
-            resource_type="patient",
-            operation="Observation",
-            interaction="read",
-            scope=None,
-        ),
-        FhirScopeParserResult(
-            resource_type="patient",
-            operation="Organization",
-            interaction="read",
-            scope=None,
-        ),
-        FhirScopeParserResult(
-            resource_type="patient", operation="Patient", interaction="read", scope=None
-        ),
-        FhirScopeParserResult(
-            resource_type="patient",
-            operation="Practitioner",
-            interaction="read",
-            scope=None,
-        ),
-        FhirScopeParserResult(
-            resource_type="patient",
-            operation="PractitionerRole",
-            interaction="read",
-            scope=None,
-        ),
-        FhirScopeParserResult(
-            resource_type="patient",
-            operation="Procedure",
-            interaction="read",
-            scope=None,
-        ),
-        FhirScopeParserResult(
-            resource_type="patient",
-            operation="Provenance",
-            interaction="read",
-            scope=None,
-        ),
-        FhirScopeParserResult(
-            resource_type="patient",
-            operation="RelatedPerson",
-            interaction="read",
-            scope=None,
-        ),
+    ],
+    ids=["Patient Scopes", "User Scopes", "System Scopes", "Non-Smart on FHIR Scopes"],
+)
+def test_fhir_scope_parser_launch_patient_parsing(
+    scopes: List[str], expected: bool
+) -> None:
+    no_patient_scope_parser: FhirScopeParser = FhirScopeParser(scopes)
+    assert no_patient_scope_parser.parsed_scopes is not None
+    assert (
         FhirScopeParserResult(
             resource_type="launch", operation=None, interaction="patient", scope=None
-        ),
-    ]
-
-
-def test_fhir_scope_parser_remove_invalid_launch_patient() -> None:
-    no_patient_scope_parser: FhirScopeParser = FhirScopeParser(
-        scopes=[
-            (
-                "launch/patient offline_access openid profile user/AllergyIntolerance.read user/Appointment.read "
-                "user/CarePlan.read user/Encounter.read user/Immunization.read user/MedicationAdministration.read "
-                "user/MedicationRequest.read user/Organization.read user/Practitioner.read user/Schedule.read "
-                "user/Slot.read"
-            )
-        ]
-    )
-    # list of scopes to validate against, notably excluding parsed "launch/patient"
-    valid_parsed_scopes: List[FhirScopeParserResult] = [
-        FhirScopeParserResult(
-            resource_type=None, operation=None, interaction=None, scope="offline_access"
-        ),
-        FhirScopeParserResult(
-            resource_type=None, operation=None, interaction=None, scope="openid"
-        ),
-        FhirScopeParserResult(
-            resource_type=None, operation=None, interaction=None, scope="profile"
-        ),
-        FhirScopeParserResult(
-            resource_type="user",
-            operation="AllergyIntolerance",
-            interaction="read",
-            scope=None,
-        ),
-        FhirScopeParserResult(
-            resource_type="user",
-            operation="Appointment",
-            interaction="read",
-            scope=None,
-        ),
-        FhirScopeParserResult(
-            resource_type="user", operation="CarePlan", interaction="read", scope=None
-        ),
-        FhirScopeParserResult(
-            resource_type="user", operation="Encounter", interaction="read", scope=None
-        ),
-        FhirScopeParserResult(
-            resource_type="user",
-            operation="Immunization",
-            interaction="read",
-            scope=None,
-        ),
-        FhirScopeParserResult(
-            resource_type="user",
-            operation="MedicationAdministration",
-            interaction="read",
-            scope=None,
-        ),
-        FhirScopeParserResult(
-            resource_type="user",
-            operation="MedicationRequest",
-            interaction="read",
-            scope=None,
-        ),
-        FhirScopeParserResult(
-            resource_type="user",
-            operation="Organization",
-            interaction="read",
-            scope=None,
-        ),
-        FhirScopeParserResult(
-            resource_type="user",
-            operation="Practitioner",
-            interaction="read",
-            scope=None,
-        ),
-        FhirScopeParserResult(
-            resource_type="user", operation="Schedule", interaction="read", scope=None
-        ),
-        FhirScopeParserResult(
-            resource_type="user", operation="Slot", interaction="read", scope=None
-        ),
-    ]
-
-    assert no_patient_scope_parser.parsed_scopes is not None
-    assert no_patient_scope_parser.parsed_scopes == valid_parsed_scopes
+        )
+        in no_patient_scope_parser.parsed_scopes
+    ) is expected

--- a/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser_correct_allow.py
+++ b/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser_correct_allow.py
@@ -4,9 +4,15 @@ from helix_fhir_client_sdk.utilities.fhir_scope_parser import FhirScopeParser
 def test_fhir_scope_parser_correct_patient_allow() -> None:
     scope_parser: FhirScopeParser = FhirScopeParser(
         scopes=[
-            """
-patient/AllergyIntolerance.read patient/Binary.read patient/CarePlan.read patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/Medication.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read patient/Procedure.read patient/Provenance.read patient/RelatedPerson.Read launch/patient        
-        """
+            (
+                "patient/AllergyIntolerance.read patient/Binary.read patient/CarePlan.read patient/CareTeam.read "
+                "patient/Condition.read patient/Device.read patient/DiagnosticReport.read "
+                "patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read "
+                "patient/Location.read patient/Medication.read patient/MedicationRequest.read patient/Observation.read "
+                "patient/Organization.read patient/Patient.read patient/Practitioner.read "
+                "patient/PractitionerRole.read patient/Procedure.read patient/Provenance.read "
+                "patient/RelatedPerson.read launch/patient"
+            )
         ]
     )
 
@@ -33,9 +39,14 @@ patient/AllergyIntolerance.read patient/Binary.read patient/CarePlan.read patien
 def test_fhir_scope_parser_correct_user_allow() -> None:
     user_scope_parser: FhirScopeParser = FhirScopeParser(
         scopes=[
-            """
-user/AllergyIntolerance.read user/Binary.read user/CarePlan.read user/CareTeam.read user/Condition.read user/Device.read user/DiagnosticReport.read user/DocumentReference.read user/Encounter.read user/Goal.read user/Immunization.read user/Location.read user/Medication.read user/MedicationRequest.read user/Observation.read user/Organization.read user/Patient.read user/Practitioner.read user/PractitionerRole.read user/Procedure.read user/Provenance.read user/RelatedPerson.Read       
-        """
+            (
+                "user/AllergyIntolerance.read user/Binary.read user/CarePlan.read user/CareTeam.read "
+                "user/Condition.read user/Device.read user/DiagnosticReport.read user/DocumentReference.read "
+                "user/Encounter.read user/Goal.read user/Immunization.read user/Location.read user/Medication.read "
+                "user/MedicationRequest.read user/Observation.read user/Organization.read user/Patient.read "
+                "user/Practitioner.read user/PractitionerRole.read user/Procedure.read user/Provenance.read "
+                "user/RelatedPerson.read"
+            )
         ]
     )
 

--- a/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser_correct_allow.py
+++ b/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser_correct_allow.py
@@ -41,11 +41,72 @@ def test_fhir_scope_parser_remove_invalid_launch_patient() -> None:
 launch/patient offline_access openid profile user/AllergyIntolerance.read user/Appointment.read user/CarePlan.read user/Encounter.read user/Immunization.read user/MedicationAdministration.read user/MedicationRequest.read user/Organization.read user/Practitioner.read user/Schedule.read user/Slot.read"""
         ]
     )
+    # list of scopes to validate against, notably excluding parsed "launch/patient"
+    valid_parsed_scopes = [
+        FhirScopeParserResult(
+            resource_type=None, operation=None, interaction=None, scope="offline_access"
+        ),
+        FhirScopeParserResult(
+            resource_type=None, operation=None, interaction=None, scope="openid"
+        ),
+        FhirScopeParserResult(
+            resource_type=None, operation=None, interaction=None, scope="profile"
+        ),
+        FhirScopeParserResult(
+            resource_type="user",
+            operation="AllergyIntolerance",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="user",
+            operation="Appointment",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="user", operation="CarePlan", interaction="read", scope=None
+        ),
+        FhirScopeParserResult(
+            resource_type="user", operation="Encounter", interaction="read", scope=None
+        ),
+        FhirScopeParserResult(
+            resource_type="user",
+            operation="Immunization",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="user",
+            operation="MedicationAdministration",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="user",
+            operation="MedicationRequest",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="user",
+            operation="Organization",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="user",
+            operation="Practitioner",
+            interaction="read",
+            scope=None,
+        ),
+        FhirScopeParserResult(
+            resource_type="user", operation="Schedule", interaction="read", scope=None
+        ),
+        FhirScopeParserResult(
+            resource_type="user", operation="Slot", interaction="read", scope=None
+        ),
+    ]
 
     assert no_patient_scope_parser.parsed_scopes is not None
-    assert (
-        FhirScopeParserResult(
-            resource_type="launch", operation=None, interaction="patient", scope=None
-        )
-        not in no_patient_scope_parser.parsed_scopes
-    )
+    assert no_patient_scope_parser.parsed_scopes == valid_parsed_scopes

--- a/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser_correct_allow.py
+++ b/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser_correct_allow.py
@@ -1,5 +1,9 @@
 from helix_fhir_client_sdk.utilities.fhir_scope_parser import FhirScopeParser
 
+from helix_fhir_client_sdk.utilities.fhir_scope_parser_result import (
+    FhirScopeParserResult,
+)
+
 
 def test_fhir_scope_parser_correct_allow() -> None:
     scope_parser: FhirScopeParser = FhirScopeParser(
@@ -11,20 +15,32 @@ patient/AllergyIntolerance.read patient/Binary.read patient/CarePlan.read patien
     )
 
     assert (
-        scope_parser.scope_allows(resource_type="Patient", interaction="read") is True
+            scope_parser.scope_allows(resource_type="Patient", interaction="read") is True
     )
 
     assert (
-        scope_parser.scope_allows(resource_type="Condition", interaction="read") is True
+            scope_parser.scope_allows(resource_type="Condition", interaction="read") is True
     )
 
     assert (
-        scope_parser.scope_allows(
-            resource_type="MedicationDispense", interaction="read"
-        )
-        is False
+            scope_parser.scope_allows(
+                resource_type="MedicationDispense", interaction="read"
+            )
+            is False
     )
 
     assert (
-        scope_parser.scope_allows(resource_type="Patient", interaction="write") is False
+            scope_parser.scope_allows(resource_type="Patient", interaction="write") is False
     )
+
+
+def test_fhir_scope_parser_remove_invalid_launch_patient() -> None:
+    no_patient_scope_parser: FhirScopeParser = FhirScopeParser(
+        scopes=[
+            """
+launch/patient offline_access openid profile user/AllergyIntolerance.read user/Appointment.read user/CarePlan.read user/Encounter.read user/Immunization.read user/MedicationAdministration.read user/MedicationRequest.read user/Organization.read user/Practitioner.read user/Schedule.read user/Slot.read"""
+        ]
+    )
+
+    assert (FhirScopeParserResult(resource_type='launch', operation=None, interaction='patient',
+                                  scope=None) not in no_patient_scope_parser.parsed_scopes)

--- a/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser_correct_allow.py
+++ b/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser_correct_allow.py
@@ -15,22 +15,22 @@ patient/AllergyIntolerance.read patient/Binary.read patient/CarePlan.read patien
     )
 
     assert (
-            scope_parser.scope_allows(resource_type="Patient", interaction="read") is True
+        scope_parser.scope_allows(resource_type="Patient", interaction="read") is True
     )
 
     assert (
-            scope_parser.scope_allows(resource_type="Condition", interaction="read") is True
+        scope_parser.scope_allows(resource_type="Condition", interaction="read") is True
     )
 
     assert (
-            scope_parser.scope_allows(
-                resource_type="MedicationDispense", interaction="read"
-            )
-            is False
+        scope_parser.scope_allows(
+            resource_type="MedicationDispense", interaction="read"
+        )
+        is False
     )
 
     assert (
-            scope_parser.scope_allows(resource_type="Patient", interaction="write") is False
+        scope_parser.scope_allows(resource_type="Patient", interaction="write") is False
     )
 
 
@@ -42,5 +42,10 @@ launch/patient offline_access openid profile user/AllergyIntolerance.read user/A
         ]
     )
 
-    assert (FhirScopeParserResult(resource_type='launch', operation=None, interaction='patient',
-                                  scope=None) not in no_patient_scope_parser.parsed_scopes)
+    assert no_patient_scope_parser.parsed_scopes is not None
+    assert (
+        FhirScopeParserResult(
+            resource_type="launch", operation=None, interaction="patient", scope=None
+        )
+        not in no_patient_scope_parser.parsed_scopes
+    )

--- a/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser_correct_allow.py
+++ b/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser_correct_allow.py
@@ -1,5 +1,6 @@
-from helix_fhir_client_sdk.utilities.fhir_scope_parser import FhirScopeParser
+from typing import List
 
+from helix_fhir_client_sdk.utilities.fhir_scope_parser import FhirScopeParser
 from helix_fhir_client_sdk.utilities.fhir_scope_parser_result import (
     FhirScopeParserResult,
 )
@@ -42,7 +43,7 @@ launch/patient offline_access openid profile user/AllergyIntolerance.read user/A
         ]
     )
     # list of scopes to validate against, notably excluding parsed "launch/patient"
-    valid_parsed_scopes = [
+    valid_parsed_scopes: List[FhirScopeParserResult] = [
         FhirScopeParserResult(
             resource_type=None, operation=None, interaction=None, scope="offline_access"
         ),

--- a/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser_correct_allow.py
+++ b/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser_correct_allow.py
@@ -1,73 +1,74 @@
+from pytest import mark
+from typing import List
 from helix_fhir_client_sdk.utilities.fhir_scope_parser import FhirScopeParser
 
 
-def test_fhir_scope_parser_correct_patient_allow() -> None:
-    scope_parser: FhirScopeParser = FhirScopeParser(
-        scopes=[
-            (
-                "patient/AllergyIntolerance.read patient/Binary.read patient/CarePlan.read patient/CareTeam.read "
-                "patient/Condition.read patient/Device.read patient/DiagnosticReport.read "
-                "patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read "
-                "patient/Location.read patient/Medication.read patient/MedicationRequest.read patient/Observation.read "
-                "patient/Organization.read patient/Patient.read patient/Practitioner.read "
-                "patient/PractitionerRole.read patient/Procedure.read patient/Provenance.read "
-                "patient/RelatedPerson.read launch/patient"
-            )
-        ]
-    )
-
+@mark.parametrize(
+    argnames="scopes,expected",
+    argvalues=[
+        (
+            [
+                (
+                    "patient/AllergyIntolerance.read patient/Binary.read patient/CarePlan.read patient/CareTeam.read "
+                    "patient/Condition.read patient/Device.read patient/DiagnosticReport.read "
+                    "patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read "
+                    "patient/Location.read patient/Medication.read patient/MedicationRequest.read "
+                    "patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read "
+                    "patient/PractitionerRole.read patient/Procedure.read patient/Provenance.read "
+                    "patient/RelatedPerson.read launch/patient"
+                )
+            ],
+            [True, True, False, False],
+        ),
+        (
+            [
+                (
+                    "user/AllergyIntolerance.read user/Binary.read user/CarePlan.read user/CareTeam.read "
+                    "user/Condition.read user/Device.read user/DiagnosticReport.read user/DocumentReference.read "
+                    "user/Encounter.read user/Goal.read user/Immunization.read user/Location.read user/Medication.read "
+                    "user/MedicationDispense.read user/Observation.read user/Organization.read user/Patient.read "
+                    "user/Practitioner.read user/PractitionerRole.read user/Procedure.read user/Provenance.read "
+                    "user/RelatedPerson.read"
+                )
+            ],
+            [True, True, True, False],
+        ),
+        (
+            [
+                (
+                    "system/AllergyIntolerance.read system/Binary.read system/CarePlan.read system/CareTeam.read "
+                    "system/Device.read system/DiagnosticReport.read system/DocumentReference.read "
+                    "system/Encounter.read system/Goal.read system/Immunization.read system/Location.read "
+                    "system/MedicationRequest.read system/Observation.read system/Organization.read "
+                    "system/Patient.read system/Medication.read system/Practitioner.read system/PractitionerRole.read "
+                    "system/Procedure.read system/Provenance.read system/RelatedPerson.read system/Patient.write"
+                )
+            ],
+            [True, False, False, True],
+        ),
+        ([], [True, True, True, True]),
+    ],
+    ids=["Patient Scopes", "User Scopes", "System Scopes", "Non-SMART on FHIR Scopes"],
+)
+def test_fhir_scope_parser_correct_allow(
+    scopes: List[str], expected: List[bool]
+) -> None:
+    scope_parser: FhirScopeParser = FhirScopeParser(scopes)
     assert (
-        scope_parser.scope_allows(resource_type="Patient", interaction="read") is True
+        scope_parser.scope_allows(resource_type="Patient", interaction="read")
+        is expected[0]
     )
-
     assert (
-        scope_parser.scope_allows(resource_type="Condition", interaction="read") is True
+        scope_parser.scope_allows(resource_type="Condition", interaction="read")
+        is expected[1]
     )
-
     assert (
         scope_parser.scope_allows(
             resource_type="MedicationDispense", interaction="read"
         )
-        is False
+        is expected[2]
     )
-
     assert (
-        scope_parser.scope_allows(resource_type="Patient", interaction="write") is False
-    )
-
-
-def test_fhir_scope_parser_correct_user_allow() -> None:
-    user_scope_parser: FhirScopeParser = FhirScopeParser(
-        scopes=[
-            (
-                "user/AllergyIntolerance.read user/Binary.read user/CarePlan.read user/CareTeam.read "
-                "user/Condition.read user/Device.read user/DiagnosticReport.read user/DocumentReference.read "
-                "user/Encounter.read user/Goal.read user/Immunization.read user/Location.read user/Medication.read "
-                "user/MedicationRequest.read user/Observation.read user/Organization.read user/Patient.read "
-                "user/Practitioner.read user/PractitionerRole.read user/Procedure.read user/Provenance.read "
-                "user/RelatedPerson.read"
-            )
-        ]
-    )
-
-    assert (
-        user_scope_parser.scope_allows(resource_type="Patient", interaction="read")
-        is True
-    )
-
-    assert (
-        user_scope_parser.scope_allows(resource_type="Condition", interaction="read")
-        is True
-    )
-
-    assert (
-        user_scope_parser.scope_allows(
-            resource_type="MedicationDispense", interaction="read"
-        )
-        is False
-    )
-
-    assert (
-        user_scope_parser.scope_allows(resource_type="Patient", interaction="write")
-        is False
+        scope_parser.scope_allows(resource_type="Patient", interaction="write")
+        is expected[3]
     )

--- a/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser_correct_allow.py
+++ b/helix_fhir_client_sdk/utilities/test/test_fhir_scope_parser_correct_allow.py
@@ -1,12 +1,7 @@
-from typing import List
-
 from helix_fhir_client_sdk.utilities.fhir_scope_parser import FhirScopeParser
-from helix_fhir_client_sdk.utilities.fhir_scope_parser_result import (
-    FhirScopeParserResult,
-)
 
 
-def test_fhir_scope_parser_correct_allow() -> None:
+def test_fhir_scope_parser_correct_patient_allow() -> None:
     scope_parser: FhirScopeParser = FhirScopeParser(
         scopes=[
             """
@@ -35,79 +30,33 @@ patient/AllergyIntolerance.read patient/Binary.read patient/CarePlan.read patien
     )
 
 
-def test_fhir_scope_parser_remove_invalid_launch_patient() -> None:
-    no_patient_scope_parser: FhirScopeParser = FhirScopeParser(
+def test_fhir_scope_parser_correct_user_allow() -> None:
+    user_scope_parser: FhirScopeParser = FhirScopeParser(
         scopes=[
             """
-launch/patient offline_access openid profile user/AllergyIntolerance.read user/Appointment.read user/CarePlan.read user/Encounter.read user/Immunization.read user/MedicationAdministration.read user/MedicationRequest.read user/Organization.read user/Practitioner.read user/Schedule.read user/Slot.read"""
+user/AllergyIntolerance.read user/Binary.read user/CarePlan.read user/CareTeam.read user/Condition.read user/Device.read user/DiagnosticReport.read user/DocumentReference.read user/Encounter.read user/Goal.read user/Immunization.read user/Location.read user/Medication.read user/MedicationRequest.read user/Observation.read user/Organization.read user/Patient.read user/Practitioner.read user/PractitionerRole.read user/Procedure.read user/Provenance.read user/RelatedPerson.Read       
+        """
         ]
     )
-    # list of scopes to validate against, notably excluding parsed "launch/patient"
-    valid_parsed_scopes: List[FhirScopeParserResult] = [
-        FhirScopeParserResult(
-            resource_type=None, operation=None, interaction=None, scope="offline_access"
-        ),
-        FhirScopeParserResult(
-            resource_type=None, operation=None, interaction=None, scope="openid"
-        ),
-        FhirScopeParserResult(
-            resource_type=None, operation=None, interaction=None, scope="profile"
-        ),
-        FhirScopeParserResult(
-            resource_type="user",
-            operation="AllergyIntolerance",
-            interaction="read",
-            scope=None,
-        ),
-        FhirScopeParserResult(
-            resource_type="user",
-            operation="Appointment",
-            interaction="read",
-            scope=None,
-        ),
-        FhirScopeParserResult(
-            resource_type="user", operation="CarePlan", interaction="read", scope=None
-        ),
-        FhirScopeParserResult(
-            resource_type="user", operation="Encounter", interaction="read", scope=None
-        ),
-        FhirScopeParserResult(
-            resource_type="user",
-            operation="Immunization",
-            interaction="read",
-            scope=None,
-        ),
-        FhirScopeParserResult(
-            resource_type="user",
-            operation="MedicationAdministration",
-            interaction="read",
-            scope=None,
-        ),
-        FhirScopeParserResult(
-            resource_type="user",
-            operation="MedicationRequest",
-            interaction="read",
-            scope=None,
-        ),
-        FhirScopeParserResult(
-            resource_type="user",
-            operation="Organization",
-            interaction="read",
-            scope=None,
-        ),
-        FhirScopeParserResult(
-            resource_type="user",
-            operation="Practitioner",
-            interaction="read",
-            scope=None,
-        ),
-        FhirScopeParserResult(
-            resource_type="user", operation="Schedule", interaction="read", scope=None
-        ),
-        FhirScopeParserResult(
-            resource_type="user", operation="Slot", interaction="read", scope=None
-        ),
-    ]
 
-    assert no_patient_scope_parser.parsed_scopes is not None
-    assert no_patient_scope_parser.parsed_scopes == valid_parsed_scopes
+    assert (
+        user_scope_parser.scope_allows(resource_type="Patient", interaction="read")
+        is True
+    )
+
+    assert (
+        user_scope_parser.scope_allows(resource_type="Condition", interaction="read")
+        is True
+    )
+
+    assert (
+        user_scope_parser.scope_allows(
+            resource_type="MedicationDispense", interaction="read"
+        )
+        is False
+    )
+
+    assert (
+        user_scope_parser.scope_allows(resource_type="Patient", interaction="write")
+        is False
+    )


### PR DESCRIPTION
Changes associated with [IOP-1415](https://icanbwell.atlassian.net/browse/IOP-1415), specifically:

1. Adding warnings when `scopes` are parsed and do not include `read` permissions for patient demographic information
2. Adding a check during scope parsing for whenever the `launch/patient` scope is included that a corresponding `patient/xxx` scope is also included, and if not removing the unused `launch/patient` scope (per Imran)
3. Associated tests

[IOP-1415]: https://icanbwell.atlassian.net/browse/IOP-1415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ