### PR TITLE
fix bug when there is empty bundle and we ask to expand it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+from typing_extensions import Optionalfrom helix_fhir_client_sdk.responses.fhir_get_response import FhirGetResponsefrom build.lib.helix_fhir_client_sdk.responses.fhir_get_response import FhirGetResponsefrom helix_fhir_client_sdk.responses.fhir_get_response import FhirGetResponse
+
 # helix.fhir.client.sdk
 
 <p align="left">
@@ -40,3 +42,40 @@ https://github.com/icanbwell/fhir-server-performance
 * 1.x supports python 3.7+ 
 * 2.x supports python 3.10+
 * 3.x supports python 3.12+
+
+# Asynchronous Support
+When communicating with FHIR servers, a lot of time is spent waiting for the server to respond. 
+This is a good use case for using asynchronous programming. 
+This SDK supports asynchronous programming using the `async` and `await` keywords.
+
+The return types are Python AsyncGenerators.  Python makes it very easy to work with AsyncGenerators.
+
+For example, if the SDK provides a function like this:
+```python
+
+async def get_resources(self) -> AsyncGenerator[FhirGetResponse, None]:
+    ...
+```
+
+You can iterate over the results as they become available:
+```python
+response: Optional[FhirGetResponse]
+async for response in client.get_resources():
+    print(response.resource)
+```
+
+Or you can get a list of responses (which will return AFTER all the responses are received:
+```python
+
+responses: List[FhirGetResponse] = [response async for response in client.get_resources()]
+```
+
+Or you can aggregate the responses into one response (which will return AFTER all the responses are received:
+```python
+
+response: Optional[FhirGetResponse] = await FhirGetResponse.from_async_generator(client.get_resources())
+```
+
+# Data Streaming
+For FHIR servers that support data streaming (e.g., b.well FHIR server), you can just set the `use_data_streaming` parameter to stream the data as it i received.
+The data will be streamed in AsyncGenerators as described above.

--- a/helix_fhir_client_sdk/fhir_merge_mixin.py
+++ b/helix_fhir_client_sdk/fhir_merge_mixin.py
@@ -297,7 +297,7 @@ class FhirMergeMixin(FhirClientProtocol):
         id_: Optional[str] = None,
         json_data_list: List[str],
         batch_size: Optional[int] = None,
-    ) -> FhirMergeResponse:
+    ) -> Optional[FhirMergeResponse]:
         """
         Calls $merge function on FHIR server
 
@@ -308,7 +308,7 @@ class FhirMergeMixin(FhirClientProtocol):
         :return: response
         """
 
-        result: FhirMergeResponse = AsyncRunner.run(
+        result: Optional[FhirMergeResponse] = AsyncRunner.run(
             FhirMergeResponse.from_async_generator(
                 self.merge_async(
                     id_=id_, json_data_list=json_data_list, batch_size=batch_size

--- a/helix_fhir_client_sdk/graph/fhir_graph_mixin.py
+++ b/helix_fhir_client_sdk/graph/fhir_graph_mixin.py
@@ -69,7 +69,7 @@ class FhirGraphMixin(FhirClientProtocol):
         *,
         graph_definition: GraphDefinition,
         contained: bool,
-    ) -> FhirGetResponse:
+    ) -> Optional[FhirGetResponse]:
 
         return AsyncRunner.run(
             FhirGetResponse.from_async_generator(

--- a/helix_fhir_client_sdk/graph/simulated_graph_processor_mixin.py
+++ b/helix_fhir_client_sdk/graph/simulated_graph_processor_mixin.py
@@ -494,7 +494,7 @@ class SimulatedGraphProcessorMixin(ABC, FhirClientProtocol):
                         )
 
             if cached_response:
-                result.append([cached_response])
+                result.append(cached_response)
         elif cached_response:
             result = cached_response
         assert result
@@ -540,7 +540,7 @@ class SimulatedGraphProcessorMixin(ABC, FhirClientProtocol):
             assert self._additional_parameters is not None
             self._additional_parameters.append("contained=true")
 
-        result: FhirGetResponse = await FhirGetResponse.from_async_generator(
+        result: Optional[FhirGetResponse] = await FhirGetResponse.from_async_generator(
             self.process_simulate_graph_async(
                 id_=id_,
                 graph_json=graph_json,
@@ -559,6 +559,7 @@ class SimulatedGraphProcessorMixin(ABC, FhirClientProtocol):
                 auth_scopes=self._auth_scopes,
             )
         )
+        assert result, "No result returned from simulate_graph_async"
         return result
 
     # noinspection PyPep8Naming

--- a/helix_fhir_client_sdk/responses/fhir_delete_response.py
+++ b/helix_fhir_client_sdk/responses/fhir_delete_response.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, AsyncGenerator
 
 
 class FhirDeleteResponse:
@@ -33,3 +33,32 @@ class FhirDeleteResponse:
         """ Number of resources deleted """
         self.count: Optional[int] = count
         self.resource_type: Optional[str] = resource_type
+
+    def append(self, other: Optional["FhirDeleteResponse"]) -> None:
+        """
+        Appends another FhirDeleteResponse to this one
+
+        :param other: FhirDeleteResponse to append
+        """
+        if other:
+            self.responses += other.responses
+            self.error = (self.error or "") + (other.error or "")
+            self.count = (self.count or 0) + (other.count or 0)
+
+    @classmethod
+    async def from_async_generator(
+        cls, generator: AsyncGenerator["FhirDeleteResponse", None]
+    ) -> Optional["FhirDeleteResponse"]:
+        """
+        Reads a generator of FhirDeleteResponse and returns a single FhirDeleteResponse by appending all the FhirDeleteResponse
+
+        :param generator: generator of FhirDeleteResponse items
+        :return: FhirDeleteResponse
+        """
+        result: FhirDeleteResponse | None = None
+        async for value in generator:
+            if not result:
+                result = value
+            else:
+                result.append(value)
+        return result

--- a/helix_fhir_client_sdk/responses/fhir_merge_response.py
+++ b/helix_fhir_client_sdk/responses/fhir_merge_response.py
@@ -30,22 +30,21 @@ class FhirMergeResponse:
         self.data: str = json_data
         self.successful: bool = status != 200
 
-    def append(self, other: Optional[List["FhirMergeResponse"]]) -> None:
+    def append(self, other: Optional["FhirMergeResponse"]) -> None:
         """
         Appends another FhirMergeResponse to this one
 
         :param other: FhirMergeResponse to append
         """
         if other:
-            for r in other:
-                self.responses.extend(r.responses)
-                self.error = (self.error or "") + (r.error or "")
-                self.successful = self.successful and r.successful
+            self.responses.extend(other.responses)
+            self.error = (self.error or "") + (other.error or "")
+            self.successful = self.successful and other.successful
 
-    @staticmethod
+    @classmethod
     async def from_async_generator(
-        generator: AsyncGenerator["FhirMergeResponse", None]
-    ) -> "FhirMergeResponse":
+        cls, generator: AsyncGenerator["FhirMergeResponse", None]
+    ) -> Optional["FhirMergeResponse"]:
         """
         Reads a generator of FhirGetResponse and returns a single FhirGetResponse by appending all the FhirGetResponse
 
@@ -57,7 +56,7 @@ class FhirMergeResponse:
             if not result:
                 result = value
             else:
-                result.append([value])
+                result.append(value)
 
         assert result
         return result

--- a/helix_fhir_client_sdk/responses/fhir_response_processor.py
+++ b/helix_fhir_client_sdk/responses/fhir_response_processor.py
@@ -387,7 +387,6 @@ class FhirResponseProcessor:
                         extra_context_to_return=extra_context_to_return,
                         resource_or_bundle=response_json,
                         separate_bundle_resources=separate_bundle_resources,
-                        text=text,
                         total_count=total_count,
                         url=url,
                     )
@@ -434,7 +433,6 @@ class FhirResponseProcessor:
         extra_context_to_return: Optional[Dict[str, Any]],
         resource_or_bundle: Dict[str, Any],
         separate_bundle_resources: bool,
-        text: str,
         total_count: int,
         url: Optional[str],
     ) -> Tuple[str, int]:
@@ -470,14 +468,14 @@ class FhirResponseProcessor:
             )
             resources_json = json.dumps(resource_separator_result.resources_dicts)
             total_count = resource_separator_result.total_count
-        elif resources:
+        elif len(resources) > 0:
             total_count = len(resources)
             if len(resources) == 1:
                 resources_json = json.dumps(resources[0])
             else:
                 resources_json = json.dumps(resources)
         else:
-            resources_json = text
+            resources_json = json.dumps(resources)
 
         return resources_json, total_count
 
@@ -619,7 +617,6 @@ class FhirResponseProcessor:
                                         extra_context_to_return=extra_context_to_return,
                                         resource_or_bundle=completed_resource,
                                         separate_bundle_resources=separate_bundle_resources,
-                                        text=json.dumps(completed_resource),
                                         total_count=total_count,
                                         url=url,
                                     )

--- a/helix_fhir_client_sdk/responses/fhir_update_response.py
+++ b/helix_fhir_client_sdk/responses/fhir_update_response.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, AsyncGenerator
 
 
 class FhirUpdateResponse:
@@ -29,3 +29,31 @@ class FhirUpdateResponse:
         self.access_token: Optional[str] = access_token
         self.status: int = status
         self.resource_type: Optional[str] = resource_type
+
+    def append(self, other: Optional["FhirUpdateResponse"]) -> None:
+        """
+        Appends another FhirUpdateResponse to this one
+
+        :param other: FhirUpdateResponse to append
+        """
+        if other:
+            self.responses += other.responses
+            self.error = (self.error or "") + (other.error or "")
+
+    @classmethod
+    async def from_async_generator(
+        cls, generator: AsyncGenerator["FhirUpdateResponse", None]
+    ) -> Optional["FhirUpdateResponse"]:
+        """
+        Reads a generator of FhirUpdateResponse and returns a single FhirUpdateResponse by appending all the FhirUpdateResponse
+
+        :param generator: generator of FhirUpdateResponse items
+        :return: FhirUpdateResponse
+        """
+        result: FhirUpdateResponse | None = None
+        async for value in generator:
+            if not result:
+                result = value
+            else:
+                result.append(value)
+        return result

--- a/helix_fhir_client_sdk/responses/get_result.py
+++ b/helix_fhir_client_sdk/responses/get_result.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, AsyncGenerator
 
 
 @dataclasses.dataclass
@@ -7,3 +7,33 @@ class GetResult:
     request_id: Optional[str]
     resources: List[Dict[str, Any]]
     response_headers: Optional[List[str]]
+
+    def append(self, other: Optional["GetResult"]) -> None:
+        """
+        Appends another GetResult to this one
+
+        :param other: GetResult to append
+        """
+        if other:
+            self.resources.extend(other.resources)
+            self.response_headers = (self.response_headers or []) + (
+                other.response_headers or []
+            )
+
+    @classmethod
+    async def from_async_generator(
+        cls, generator: AsyncGenerator["GetResult", None]
+    ) -> Optional["GetResult"]:
+        """
+        Reads a generator of GetResult and returns a single GetResult by appending all the GetResult
+
+        :param generator: generator of GetResult items
+        :return: GetResult
+        """
+        result: GetResult | None = None
+        async for value in generator:
+            if not result:
+                result = value
+            else:
+                result.append(value)
+        return result

--- a/helix_fhir_client_sdk/responses/paging_result.py
+++ b/helix_fhir_client_sdk/responses/paging_result.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, AsyncGenerator
 
 
 @dataclasses.dataclass
@@ -8,3 +8,34 @@ class PagingResult:
     resources: List[Dict[str, Any]]
     page_number: int
     response_headers: Optional[List[str]]
+
+    def append(self, other: Optional["PagingResult"]) -> None:
+        """
+        Appends another PagingResult to this one
+
+        :param other: PagingResult to append
+        """
+        if other:
+            self.resources.extend(other.resources)
+            self.response_headers = (self.response_headers or []) + (
+                other.response_headers or []
+            )
+            self.page_number = other.page_number
+
+    @classmethod
+    async def from_async_generator(
+        cls, generator: AsyncGenerator["PagingResult", None]
+    ) -> Optional["PagingResult"]:
+        """
+        Reads a generator of PagingResult and returns a single PagingResult by appending all the PagingResult
+
+        :param generator: generator of PagingResult items
+        :return: PagingResult
+        """
+        result: PagingResult | None = None
+        async for value in generator:
+            if not result:
+                result = value
+            else:
+                result.append(value)
+        return result

--- a/helix_fhir_client_sdk/responses/test/fhir_response_processor/test_expand_or_separate_bundle_async.py
+++ b/helix_fhir_client_sdk/responses/test/fhir_response_processor/test_expand_or_separate_bundle_async.py
@@ -28,7 +28,6 @@ async def test_expand_or_separate_bundle_async() -> None:
             extra_context_to_return=extra_context_to_return,
             resource_or_bundle=response_json,
             separate_bundle_resources=separate_bundle_resources,
-            text=text,
             total_count=total_count,
             url=url,
         )

--- a/helix_fhir_client_sdk/responses/test/fhir_response_processor/test_expand_or_separate_bundle_async.py
+++ b/helix_fhir_client_sdk/responses/test/fhir_response_processor/test_expand_or_separate_bundle_async.py
@@ -19,7 +19,6 @@ async def test_expand_or_separate_bundle_async() -> None:
     expand_fhir_bundle = True
     separate_bundle_resources = False
     extra_context_to_return = None
-    text = '{"resourceType": "Bundle", "total": 2, "entry": [{"resource": {"resourceType": "Patient", "id": "1"}}, {"resource": {"resourceType": "Patient", "id": "2"}}]}'
 
     result_resources_json, result_total_count = (
         await FhirResponseProcessor.expand_or_separate_bundle_async(

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.12",
+    python_requires=">=3.10",
     dependency_links=[],
     include_package_data=True,
     zip_safe=False,

--- a/tests/async/fhir_server/test_async_real_fhir_server_get_graph_large.py
+++ b/tests/async/fhir_server/test_async_real_fhir_server_get_graph_large.py
@@ -76,9 +76,12 @@ async def test_async_real_fhir_server_get_graph_large(
     expected_resource_count = len(bundle["entry"])
     print("expected_resource_count", expected_resource_count)
 
-    merge_response: FhirMergeResponse = await FhirMergeResponse.from_async_generator(
-        fhir_client.merge_async(json_data_list=[json.dumps(bundle)])
+    merge_response: Optional[FhirMergeResponse] = (
+        await FhirMergeResponse.from_async_generator(
+            fhir_client.merge_async(json_data_list=[json.dumps(bundle)])
+        )
     )
+    assert merge_response is not None
     print(json.dumps(merge_response.responses))
     assert merge_response.status == 200, merge_response.responses
     assert (
@@ -166,7 +169,7 @@ async def test_async_real_fhir_server_get_graph_large(
             if not response:
                 response = response1
             else:
-                response.append([response1])
+                response.append(response1)
 
         assert response is not None
         resources: List[Dict[str, Any]] = response.get_resources()

--- a/tests/async/fhir_server/test_async_real_fhir_server_get_patients_large.py
+++ b/tests/async/fhir_server/test_async_real_fhir_server_get_patients_large.py
@@ -36,9 +36,12 @@ async def test_async_real_fhir_server_get_patients_large(
     fhir_client = fhir_client.auth_wellknown_url(auth_well_known_url)
 
     resource = await FhirHelper.create_test_patients(count)
-    merge_response: FhirMergeResponse = await FhirMergeResponse.from_async_generator(
-        fhir_client.merge_async(json_data_list=[json.dumps(resource)])
+    merge_response: Optional[FhirMergeResponse] = (
+        await FhirMergeResponse.from_async_generator(
+            fhir_client.merge_async(json_data_list=[json.dumps(resource)])
+        )
     )
+    assert merge_response is not None
     print(merge_response.responses)
     assert merge_response.status == 200, merge_response.responses
     assert len(merge_response.responses) == count, merge_response.responses
@@ -68,7 +71,7 @@ async def test_async_real_fhir_server_get_patients_large(
             if not response:
                 response = response1
             else:
-                response.append([response1])
+                response.append(response1)
 
         assert response is not None
         assert response.response_headers is not None

--- a/tests/async/simulated_graph/test_fhir_simulated_graph_async.py
+++ b/tests/async/simulated_graph/test_fhir_simulated_graph_async.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 from mockserver_client.mockserver_client import (
     MockServerFriendlyClient,
@@ -99,7 +99,7 @@ async def test_fhir_simulated_graph_async() -> None:
         fhir_client = fhir_client.set_access_token(auth_access_token)
 
     fhir_client = fhir_client.url(absolute_url).resource("Patient")
-    response: FhirGetResponse = await FhirGetResponse.from_async_generator(
+    response: Optional[FhirGetResponse] = await FhirGetResponse.from_async_generator(
         fhir_client.simulate_graph_streaming_async(
             id_="1",
             graph_json=graph_json,
@@ -107,6 +107,7 @@ async def test_fhir_simulated_graph_async() -> None:
             separate_bundle_resources=False,
         )
     )
+    assert response is not None
     print(response.responses)
 
     expected_json = {

--- a/tests/async/simulated_graph/test_fhir_simulated_graph_caching_async.py
+++ b/tests/async/simulated_graph/test_fhir_simulated_graph_caching_async.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 from mockserver_client.mockserver_client import (
     MockServerFriendlyClient,
@@ -146,7 +146,7 @@ async def test_fhir_simulated_graph_caching_async() -> None:
         fhir_client = fhir_client.set_access_token(auth_access_token)
 
     fhir_client = fhir_client.url(absolute_url).resource("Patient")
-    response: FhirGetResponse = await FhirGetResponse.from_async_generator(
+    response: Optional[FhirGetResponse] = await FhirGetResponse.from_async_generator(
         fhir_client.simulate_graph_streaming_async(
             id_="1",
             graph_json=graph_json,
@@ -154,6 +154,7 @@ async def test_fhir_simulated_graph_caching_async() -> None:
             separate_bundle_resources=False,
         )
     )
+    assert response is not None
     print(response.responses)
 
     expected_json = {

--- a/tests/async/simulated_graph/test_fhir_simulated_graph_caching_scope_parser_async.py
+++ b/tests/async/simulated_graph/test_fhir_simulated_graph_caching_scope_parser_async.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 from mockserver_client.mockserver_client import (
     MockServerFriendlyClient,
@@ -156,7 +156,7 @@ async def test_fhir_simulated_graph_caching_scope_parser_async() -> None:
         fhir_client = fhir_client.set_access_token(auth_access_token)
 
     fhir_client = fhir_client.url(absolute_url).resource("Patient")
-    response: FhirGetResponse = await FhirGetResponse.from_async_generator(
+    response: Optional[FhirGetResponse] = await FhirGetResponse.from_async_generator(
         fhir_client.simulate_graph_streaming_async(
             id_="1",
             graph_json=graph_json,
@@ -164,6 +164,7 @@ async def test_fhir_simulated_graph_caching_scope_parser_async() -> None:
             separate_bundle_resources=False,
         )
     )
+    assert response is not None
     print(response.responses)
 
     expected_json = {

--- a/tests/async/simulated_graph/test_fhir_simulated_graph_separate_resources_async.py
+++ b/tests/async/simulated_graph/test_fhir_simulated_graph_separate_resources_async.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 from mockserver_client.mockserver_client import (
     MockServerFriendlyClient,
@@ -120,7 +120,7 @@ async def test_fhir_simulated_graph_async() -> None:
     if auth_access_token:
         fhir_client = fhir_client.set_access_token(auth_access_token)
 
-    response: FhirGetResponse = await FhirGetResponse.from_async_generator(
+    response: Optional[FhirGetResponse] = await FhirGetResponse.from_async_generator(
         fhir_client.simulate_graph_streaming_async(
             id_="1",
             graph_json=graph_json,
@@ -128,6 +128,7 @@ async def test_fhir_simulated_graph_async() -> None:
             separate_bundle_resources=True,
         )
     )
+    assert response is not None
     print(response.responses)
 
     expected_json = {

--- a/tests/async/simulated_graph/test_fhir_simulated_graph_with_errors_async.py
+++ b/tests/async/simulated_graph/test_fhir_simulated_graph_with_errors_async.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 from mockserver_client.mockserver_client import (
     MockServerFriendlyClient,
@@ -93,7 +93,7 @@ async def test_fhir_simulated_graph_with_errors_async() -> None:
 
     fhir_client = fhir_client.exclude_status_codes_from_retry([401])
 
-    response: FhirGetResponse = await FhirGetResponse.from_async_generator(
+    response: Optional[FhirGetResponse] = await FhirGetResponse.from_async_generator(
         fhir_client.simulate_graph_streaming_async(
             id_="1",
             graph_json=graph_json,
@@ -101,6 +101,7 @@ async def test_fhir_simulated_graph_with_errors_async() -> None:
             separate_bundle_resources=False,
         )
     )
+    assert response is not None
     print(response.responses)
 
     assert response.url == f"http://mock-server:1080/{test_name}"

--- a/tests/async/simulated_graph/test_fhir_simulated_graph_with_operation_outcomes_async.py
+++ b/tests/async/simulated_graph/test_fhir_simulated_graph_with_operation_outcomes_async.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 from mockserver_client.mockserver_client import (
     MockServerFriendlyClient,
@@ -123,7 +123,7 @@ async def test_fhir_simulated_graph_with_operation_outcomes_async() -> None:
         fhir_client = fhir_client.set_access_token(auth_access_token)
 
     fhir_client = fhir_client.url(absolute_url).resource("Patient")
-    response: FhirGetResponse = await FhirGetResponse.from_async_generator(
+    response: Optional[FhirGetResponse] = await FhirGetResponse.from_async_generator(
         fhir_client.simulate_graph_streaming_async(
             id_="1",
             graph_json=graph_json,
@@ -131,6 +131,7 @@ async def test_fhir_simulated_graph_with_operation_outcomes_async() -> None:
             separate_bundle_resources=False,
         )
     )
+    assert response is not None
     print(response.responses)
 
     expected_json = {

--- a/tests/async/simulated_graph/test_fhir_simulated_graph_with_url_column_async.py
+++ b/tests/async/simulated_graph/test_fhir_simulated_graph_with_url_column_async.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 from mockserver_client.mockserver_client import (
     MockServerFriendlyClient,
@@ -93,7 +93,7 @@ async def test_fhir_simulated_graph_with_url_column_async() -> None:
     fhir_client = fhir_client.expand_fhir_bundle(False)
     fhir_client = fhir_client.url(absolute_url).resource("Patient")
     fhir_client = fhir_client.extra_context_to_return({"slug": "1234"})
-    response: FhirGetResponse = await FhirGetResponse.from_async_generator(
+    response: Optional[FhirGetResponse] = await FhirGetResponse.from_async_generator(
         fhir_client.simulate_graph_streaming_async(
             id_="1",
             graph_json=graph_json,
@@ -101,6 +101,7 @@ async def test_fhir_simulated_graph_with_url_column_async() -> None:
             separate_bundle_resources=False,
         )
     )
+    assert response is not None
     print(response.responses)
 
     assert (

--- a/tests/async/simulated_graph_practitioner/test_fhir_simulated_graph_multiple_practitioner_async.py
+++ b/tests/async/simulated_graph_practitioner/test_fhir_simulated_graph_multiple_practitioner_async.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 from mockserver_client.mockserver_client import (
     MockServerFriendlyClient,
@@ -150,7 +150,7 @@ async def test_fhir_simulated_graph_multiple_graph_async() -> None:
     fhir_client = fhir_client.expand_fhir_bundle(False)
 
     fhir_client = fhir_client.url(absolute_url).resource("Patient")
-    response: FhirGetResponse = await FhirGetResponse.from_async_generator(
+    response: Optional[FhirGetResponse] = await FhirGetResponse.from_async_generator(
         fhir_client.simulate_graph_streaming_async(
             id_="1",
             graph_json=graph_json,
@@ -158,6 +158,7 @@ async def test_fhir_simulated_graph_multiple_graph_async() -> None:
             separate_bundle_resources=False,
         )
     )
+    assert response is not None
     print(response.responses)
 
     expected_json = {
@@ -208,7 +209,6 @@ async def test_fhir_simulated_graph_multiple_graph_async() -> None:
             },
         ]
     }
-
     assert json.loads(response.responses) == expected_json
 
     response = await FhirGetResponse.from_async_generator(
@@ -219,6 +219,7 @@ async def test_fhir_simulated_graph_multiple_graph_async() -> None:
             separate_bundle_resources=False,
         )
     )
+    assert response is not None
     print(response.responses)
 
     expected_json = {

--- a/tests/async/simulated_graph_practitioner/test_fhir_simulated_graph_multiple_practitioner_in_one_call_async.py
+++ b/tests/async/simulated_graph_practitioner/test_fhir_simulated_graph_multiple_practitioner_in_one_call_async.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 from mockserver_client.mockserver_client import (
     MockServerFriendlyClient,
@@ -153,7 +153,7 @@ async def test_fhir_simulated_graph_multiple_graph_in_one_call_async() -> None:
     fhir_client = fhir_client.expand_fhir_bundle(False)
 
     fhir_client = fhir_client.url(absolute_url).resource("Patient")
-    response: FhirGetResponse = await FhirGetResponse.from_async_generator(
+    response: Optional[FhirGetResponse] = await FhirGetResponse.from_async_generator(
         fhir_client.simulate_graph_streaming_async(
             id_="1,2",
             graph_json=graph_json,
@@ -161,6 +161,7 @@ async def test_fhir_simulated_graph_multiple_graph_in_one_call_async() -> None:
             separate_bundle_resources=False,
         )
     )
+    assert response is not None
     print(response.responses)
 
     expected_json = {

--- a/tests/async/simulated_graph_practitioner/test_fhir_simulated_graph_practitioner_async.py
+++ b/tests/async/simulated_graph_practitioner/test_fhir_simulated_graph_practitioner_async.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 from mockserver_client.mockserver_client import (
     MockServerFriendlyClient,
@@ -93,7 +93,7 @@ async def test_fhir_simulated_graph_async() -> None:
     fhir_client = FhirClient()
     fhir_client = fhir_client.expand_fhir_bundle(False)
     fhir_client = fhir_client.url(absolute_url).resource("Patient")
-    response: FhirGetResponse = await FhirGetResponse.from_async_generator(
+    response: Optional[FhirGetResponse] = await FhirGetResponse.from_async_generator(
         fhir_client.simulate_graph_streaming_async(
             id_="1",
             graph_json=graph_json,
@@ -101,6 +101,7 @@ async def test_fhir_simulated_graph_async() -> None:
             separate_bundle_resources=False,
         )
     )
+    assert response is not None
     print(response.responses)
 
     expected_json = {

--- a/tests/async/simulated_graph_practitioner/test_fhir_simulated_graph_practitioner_separate_resources_async.py
+++ b/tests/async/simulated_graph_practitioner/test_fhir_simulated_graph_practitioner_separate_resources_async.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 from mockserver_client.mockserver_client import (
     MockServerFriendlyClient,
@@ -92,7 +92,7 @@ async def test_fhir_simulated_graph_async() -> None:
 
     fhir_client = FhirClient()
     fhir_client = fhir_client.url(absolute_url).resource("Patient")
-    response: FhirGetResponse = await FhirGetResponse.from_async_generator(
+    response: Optional[FhirGetResponse] = await FhirGetResponse.from_async_generator(
         fhir_client.simulate_graph_streaming_async(
             id_="1",
             graph_json=graph_json,
@@ -100,6 +100,7 @@ async def test_fhir_simulated_graph_async() -> None:
             separate_bundle_resources=True,
         )
     )
+    assert response is not None
     print(response.responses)
 
     expected_json = {

--- a/tests/async/test_async_fhir_client_patient_list_resource_streaming.py
+++ b/tests/async/test_async_fhir_client_patient_list_resource_streaming.py
@@ -63,7 +63,7 @@ async def test_fhir_client_patient_list_async_resource_streaming() -> None:
         if not response:
             response = response1
         else:
-            response.append([response1])
+            response.append(response1)
 
     assert response
     # assert response.responses == ""

--- a/tests/async/test_async_fhir_client_patient_list_streaming.py
+++ b/tests/async/test_async_fhir_client_patient_list_streaming.py
@@ -73,7 +73,7 @@ async def test_fhir_client_patient_list_async_streaming() -> None:
         if not response:
             response = response1
         else:
-            response.append([response1])
+            response.append(response1)
         responses.append(response1)
 
     assert response is not None

--- a/tests/async/test_async_fhir_client_patient_merge.py
+++ b/tests/async/test_async_fhir_client_patient_merge.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from mockserver_client.mockserver_client import (
     MockServerFriendlyClient,
@@ -46,9 +46,11 @@ async def test_fhir_client_patient_merge_async() -> None:
     fhir_client = FhirClient()
     fhir_client = fhir_client.url(absolute_url).resource("Patient")
     fhir_client = fhir_client.additional_request_headers(additional_request_headers)
-    response: FhirMergeResponse = await FhirMergeResponse.from_async_generator(
-        fhir_client.merge_async(json_data_list=[json.dumps(resource)])
+    response: Optional[FhirMergeResponse] = (
+        await FhirMergeResponse.from_async_generator(
+            fhir_client.merge_async(json_data_list=[json.dumps(resource)])
+        )
     )
-
+    assert response is not None
     print(response.responses)
     assert response.responses == response_text_1

--- a/tests/async/test_async_fhir_client_patient_merge_with_validate.py
+++ b/tests/async/test_async_fhir_client_patient_merge_with_validate.py
@@ -1,6 +1,6 @@
 import json
 from os import environ
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from mockserver_client.mockserver_client import (
     MockServerFriendlyClient,
@@ -52,10 +52,12 @@ async def test_fhir_client_patient_merge_with_validate_async() -> None:
     )
     fhir_client = fhir_client.auth_wellknown_url(auth_well_known_url)
     fhir_client = fhir_client.url(absolute_url).resource("Patient")
-    response: FhirMergeResponse = await FhirMergeResponse.from_async_generator(
-        fhir_client.merge_async(json_data_list=[json.dumps(resource)])
+    response: Optional[FhirMergeResponse] = (
+        await FhirMergeResponse.from_async_generator(
+            fhir_client.merge_async(json_data_list=[json.dumps(resource)])
+        )
     )
-
+    assert response is not None
     print(response.responses)
     assert response.responses == [
         {

--- a/tests/async/test_async_real_fhir_server_get_patients.py
+++ b/tests/async/test_async_real_fhir_server_get_patients.py
@@ -1,6 +1,6 @@
 import json
 from os import environ
-from typing import Any, List, Dict
+from typing import Any, List, Dict, Optional
 
 import pytest
 
@@ -39,9 +39,12 @@ async def test_async_real_fhir_server_get_patients(use_data_streaming: bool) -> 
             ],
         },
     }
-    merge_response: FhirMergeResponse = await FhirMergeResponse.from_async_generator(
-        fhir_client.merge_async(json_data_list=[json.dumps(resource)])
+    merge_response: Optional[FhirMergeResponse] = (
+        await FhirMergeResponse.from_async_generator(
+            fhir_client.merge_async(json_data_list=[json.dumps(resource)])
+        )
     )
+    assert merge_response is not None
     print(merge_response.responses)
     assert merge_response.status == 200, merge_response.responses
     assert len(merge_response.responses) == 1, merge_response.responses

--- a/tests/async/test_async_real_fhir_server_get_patients_error.py
+++ b/tests/async/test_async_real_fhir_server_get_patients_error.py
@@ -1,5 +1,6 @@
 import json
 from os import environ
+from typing import Optional
 
 from helix_fhir_client_sdk.fhir_client import FhirClient
 from helix_fhir_client_sdk.responses.fhir_merge_response import FhirMergeResponse
@@ -33,9 +34,12 @@ async def test_async_real_fhir_server_get_patients_error() -> None:
         "id": "12356",
         "meta": "bad",
     }
-    merge_response: FhirMergeResponse = await FhirMergeResponse.from_async_generator(
-        fhir_client.merge_async(json_data_list=[json.dumps(resource)])
+    merge_response: Optional[FhirMergeResponse] = (
+        await FhirMergeResponse.from_async_generator(
+            fhir_client.merge_async(json_data_list=[json.dumps(resource)])
+        )
     )
+    assert merge_response is not None
     print(merge_response.responses)
     assert merge_response.status == 200, merge_response.responses
     assert merge_response.request_id is not None

--- a/tests/sync/graph/test_fhir_graph.py
+++ b/tests/sync/graph/test_fhir_graph.py
@@ -1,4 +1,5 @@
 import json
+from typing import Optional
 
 from mockserver_client.mockserver_client import (
     MockServerFriendlyClient,
@@ -73,7 +74,8 @@ def test_fhir_graph() -> None:
     fhir_client = FhirClient()
 
     fhir_client = fhir_client.url(absolute_url).resource("Patient")
-    response: FhirGetResponse = fhir_client.graph(
+    response: Optional[FhirGetResponse] = fhir_client.graph(
         graph_definition=graph_definition, contained=False
     )
+    assert response is not None
     assert json.loads(response.responses) == response_text

--- a/tests/sync/test_fhir_client_patient_merge.py
+++ b/tests/sync/test_fhir_client_patient_merge.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from mockserver_client.mockserver_client import (
     MockServerFriendlyClient,
@@ -41,9 +41,9 @@ def test_fhir_client_patient_merge() -> None:
 
     fhir_client = FhirClient()
     fhir_client = fhir_client.url(absolute_url).resource("Patient")
-    response: FhirMergeResponse = fhir_client.merge(
+    response: Optional[FhirMergeResponse] = fhir_client.merge(
         json_data_list=[json.dumps(resource)]
     )
-
+    assert response is not None
     print(response.responses)
     assert response.responses == response_text_1


### PR DESCRIPTION
- added append() and from_async_generator() to FhirGetResponse, FhirUpdateResponse and FhirMergeResponse to make it easier to aggregate results from async calls
- Fix issue where if there was an empty bundle and expand_fhir_bundle parameter was set
- set minimum python to 3.10 in setup.py.  This allows the SDK to work with any python 3.10 or higher.