### PR TITLE
Switch call to get well known url to use RetryableClient

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: tests
         run: |
           docker compose run --rm --name helix.fhir.client.sdk -v /home/runner/work/${{ github.repository }}/reports:/reports dev pytest tests --junitxml=/reports/test-results.xml
-	      docker compose run --rm --name helix.fhir.client.sdk -v /home/runner/work/${{ github.repository }}/reports:/reports dev pytest tests_integration --junitxml=/reports/test-results-integration.xml
+          docker compose run --rm --name helix.fhir.client.sdk -v /home/runner/work/${{ github.repository }}/reports:/reports dev pytest tests_integration --junitxml=/reports/test-results-integration.xml
 
       - name: Upload pytest test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       # Checks-out your repository
       - uses: actions/checkout@v4
+
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -31,5 +32,22 @@ jobs:
       # setup and install everything and run tests
       - name: up
         run: make up
+
+      - name: Create reports output folder
+        run: mkdir -p /home/runner/work/${{ github.repository }}/reports
+
       - name: tests
-        run: make tests
+        run: docker compose run --rm --name spf_tests -v /home/runner/work/${{ github.repository }}/reports:/reports dev pytest tests spark_pipeline_framework --junitxml=/reports/test-results.xml
+
+      - name: tests
+        run: |
+          docker compose run --rm --name helix.fhir.client.sdk -v /home/runner/work/${{ github.repository }}/reports:/reports dev pytest tests --junitxml=/reports/test-results.xml
+	      docker compose run --rm --name helix.fhir.client.sdk -v /home/runner/work/${{ github.repository }}/reports:/reports dev pytest tests_integration --junitxml=/reports/test-results-integration.xml
+
+      - name: Upload pytest test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-results
+          path: /home/runner/work/${{ github.repository }}/reports/**/*.xml
+        # Use always() to always run this step to publish test results when there are test failures
+        if: ${{ always() }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -37,9 +37,6 @@ jobs:
         run: mkdir -p /home/runner/work/${{ github.repository }}/reports
 
       - name: tests
-        run: docker compose run --rm --name spf_tests -v /home/runner/work/${{ github.repository }}/reports:/reports dev pytest tests spark_pipeline_framework --junitxml=/reports/test-results.xml
-
-      - name: tests
         run: |
           docker compose run --rm --name helix.fhir.client.sdk -v /home/runner/work/${{ github.repository }}/reports:/reports dev pytest tests --junitxml=/reports/test-results.xml
 	      docker compose run --rm --name helix.fhir.client.sdk -v /home/runner/work/${{ github.repository }}/reports:/reports dev pytest tests_integration --junitxml=/reports/test-results-integration.xml

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -57,3 +57,4 @@ jobs:
           name: Pytest Report            # Name of the check run which will be created
           path: /home/runner/work/${{ github.repository }}/reports/**/*.xml    # Path to test results
           reporter: java-junit        # Format of test results
+          fail-on-error: false        # Do not change the build status if errors are found

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -21,6 +21,15 @@ jobs:
         with:
           python-version: '3.12'
 
+      # Cache pipenv dependencies
+      - name: Cache pipenv dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.local/share/virtualenvs
+          key: ${{ runner.os }}-pipenv-${{ hashFiles('Pipfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pipenv-
+
 #      - name: Docker Compose Setup
 #        run: |
 #          sudo apt-get install docker-compose-plugin
@@ -28,6 +37,11 @@ jobs:
 
       - name: pre-commit
         run: make run-pre-commit
+
+      # Run Docker Compose, passing the cache to the container
+      - name: Run with Docker Compose
+        run: |
+          docker compose up --build
 
       # setup and install everything and run tests
       - name: up

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -59,5 +59,5 @@ jobs:
         with:
           name: Pytest Report            # Name of the check run which will be created
           path: /home/runner/work/${{ github.repository }}/reports/*.xml    # Path to test results
-          reporter: junit        # Format of test results
+          reporter: java-junit        # Format of test results
           fail-on-error: false        # Do not change the build status if errors are found

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -38,8 +38,8 @@ jobs:
 
       - name: tests
         run: |
-          docker compose run --rm --name helix.fhir.client.sdk -v /home/runner/work/${{ github.repository }}/reports:/reports dev pytest tests --tb --junitxml=/reports/test-results.xml
-          docker compose run --rm --name helix.fhir.client.sdk -v /home/runner/work/${{ github.repository }}/reports:/reports dev pytest tests_integration --tb --junitxml=/reports/test-results-integration.xml
+          docker compose run --rm --name helix.fhir.client.sdk -v /home/runner/work/${{ github.repository }}/reports:/reports dev pytest tests --tb=auto --junitxml=/reports/test-results.xml
+          docker compose run --rm --name helix.fhir.client.sdk -v /home/runner/work/${{ github.repository }}/reports:/reports dev pytest tests_integration --tb=auto --junitxml=/reports/test-results-integration.xml
 
       - name: Upload pytest test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -21,15 +21,6 @@ jobs:
         with:
           python-version: '3.12'
 
-      # Cache pipenv dependencies
-      - name: Cache pipenv dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.local/share/virtualenvs
-          key: ${{ runner.os }}-pipenv-${{ hashFiles('Pipfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pipenv-
-
 #      - name: Docker Compose Setup
 #        run: |
 #          sudo apt-get install docker-compose-plugin
@@ -37,11 +28,6 @@ jobs:
 
       - name: pre-commit
         run: make run-pre-commit
-
-      # Run Docker Compose, passing the cache to the container
-      - name: Run with Docker Compose
-        run: |
-          docker compose up --build
 
       # setup and install everything and run tests
       - name: up

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -38,8 +38,8 @@ jobs:
 
       - name: tests
         run: |
-          docker compose run --rm --name helix.fhir.client.sdk -v /home/runner/work/${{ github.repository }}/reports:/reports dev pytest tests --junitxml=/reports/test-results.xml
-          docker compose run --rm --name helix.fhir.client.sdk -v /home/runner/work/${{ github.repository }}/reports:/reports dev pytest tests_integration --junitxml=/reports/test-results-integration.xml
+          docker compose run --rm --name helix.fhir.client.sdk -v /home/runner/work/${{ github.repository }}/reports:/reports dev pytest tests --tb --junitxml=/reports/test-results.xml
+          docker compose run --rm --name helix.fhir.client.sdk -v /home/runner/work/${{ github.repository }}/reports:/reports dev pytest tests_integration --tb --junitxml=/reports/test-results-integration.xml
 
       - name: Upload pytest test results
         uses: actions/upload-artifact@v4
@@ -48,3 +48,12 @@ jobs:
           path: /home/runner/work/${{ github.repository }}/reports/**/*.xml
         # Use always() to always run this step to publish test results when there are test failures
         if: ${{ always() }}
+
+      # Publish all test results in the GitHub UI
+      - name: Test Report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()    # run this step even if previous step failed
+        with:
+          name: Pytest Report            # Name of the check run which will be created
+          path: /home/runner/work/${{ github.repository }}/reports/**/*.xml    # Path to test results
+          reporter: java-junit        # Format of test results

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -49,12 +49,15 @@ jobs:
         # Use always() to always run this step to publish test results when there are test failures
         if: ${{ always() }}
 
+      - name: Verify reports are generated
+        run: ls -halt /home/runner/work/${{ github.repository }}/reports/
+
       # Publish all test results in the GitHub UI
       - name: Test Report
         uses: dorny/test-reporter@v1
-        if: success() || failure()    # run this step even if previous step failed
+        if: ${{ always() }}
         with:
           name: Pytest Report            # Name of the check run which will be created
-          path: /home/runner/work/${{ github.repository }}/reports/**/*.xml    # Path to test results
-          reporter: java-junit        # Format of test results
+          path: /home/runner/work/${{ github.repository }}/reports/*.xml    # Path to test results
+          reporter: junit        # Format of test results
           fail-on-error: false        # Do not change the build status if errors are found

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /src
 #RUN apt-get install -y git && git --version && git config --global --add safe.directory /src
 
 RUN python -m pip install --no-cache-dir pipenv
-RUN pipenv lock && pipenv sync --dev --system
+RUN pipenv sync --dev --system
 
 COPY . /src
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,8 @@ services:
       context: .
     volumes:
       - ./:/src/
-#      - ../mockserver_client/mockserver_client:/usr/local/lib/python3.12/site-packages/mockserver_client
+      - ~/.local/share/virtualenvs:/root/.local/share/virtualenvs
+    #      - ../mockserver_client/mockserver_client:/usr/local/lib/python3.12/site-packages/mockserver_client
     container_name: fhir_client_sdk_dev
     working_dir: /src
     env_file:

--- a/helix_fhir_client_sdk/fhir_client.py
+++ b/helix_fhir_client_sdk/fhir_client.py
@@ -579,17 +579,15 @@ class FhirClient(
         if self._id:
             ids = self._id if isinstance(self._id, list) else [self._id]
         # actually make the request
-        async with self.create_http_session() as http:
-            full_response: Optional[FhirGetResponse] = None
-            async for response in self._get_with_session_async(
-                session=http,
-                ids=ids,
-                fn_handle_streaming_chunk=data_chunk_handler,
-            ):
-                if response:
-                    full_response = response
-            assert full_response
-            return full_response
+        full_response: Optional[FhirGetResponse] = None
+        async for response in self._get_with_session_async(
+            ids=ids,
+            fn_handle_streaming_chunk=data_chunk_handler,
+        ):
+            if response:
+                full_response = response
+        assert full_response
+        return full_response
 
     async def get_streaming_async(
         self,
@@ -616,14 +614,12 @@ class FhirClient(
         if self._id:
             ids = self._id if isinstance(self._id, list) else [self._id]
         # actually make the request
-        async with self.create_http_session() as http:
-            full_response: Optional[FhirGetResponse]
-            async for response in self._get_with_session_async(
-                session=http,
-                ids=ids,
-                fn_handle_streaming_chunk=data_chunk_handler,
-            ):
-                yield response
+        full_response: Optional[FhirGetResponse]
+        async for response in self._get_with_session_async(
+            ids=ids,
+            fn_handle_streaming_chunk=data_chunk_handler,
+        ):
+            yield response
 
     def get(self) -> FhirGetResponse:
         """
@@ -634,10 +630,9 @@ class FhirClient(
         result: FhirGetResponse = AsyncRunner.run(self.get_async())
         return result
 
-    async def _get_with_session_async(  # type: ignore[override]
+    async def _get_with_session_async(  # type:ignore[override]
         self,
         *,
-        session: Optional[ClientSession],
         page_number: Optional[int] = None,
         ids: Optional[List[str]] = None,
         id_above: Optional[str] = None,
@@ -648,7 +643,6 @@ class FhirClient(
         issues a GET call with the specified session, page_number and ids
 
 
-        :param session:
         :param page_number:
         :param ids:
         :param id_above: return ids greater than this
@@ -923,27 +917,11 @@ class FhirClient(
                     )
             return await client.get(url=full_url, headers=headers, data=payload)
 
-    # noinspection SpellCheckingInspection
     def create_http_session(self) -> ClientSession:
         """
         Creates an HTTP Session
 
         """
-        # retry_strategy = Retry(
-        #     total=5,
-        #     status_forcelist=[429, 500, 502, 503, 504],
-        #     method_whitelist=[
-        #         "HEAD",
-        #         "GET",
-        #         "PUT",
-        #         "DELETE",
-        #         "OPTIONS",
-        #         "TRACE",
-        #         "POST",
-        #     ],
-        #     backoff_factor=5,
-        # )
-        # session: ClientSession = aiohttp.ClientSession()
         trace_config = aiohttp.TraceConfig()
         # trace_config.on_request_start.append(on_request_start)
         if self._log_level == "DEBUG":

--- a/helix_fhir_client_sdk/graph/fhir_graph_mixin.py
+++ b/helix_fhir_client_sdk/graph/fhir_graph_mixin.py
@@ -50,19 +50,17 @@ class FhirGraphMixin(FhirClientProtocol):
         else:
             id_list.append("1")
         self.id_(id_list)  # this is needed because the $graph endpoint requires an id
-        async with self.create_http_session() as http:
-            result: Optional[FhirGetResponse]
-            chunk_size: int = self._page_size or 1
-            for chunk in ListChunker.divide_into_chunks(id_list, chunk_size):
-                async for result1 in self._get_with_session_async(  # type: ignore[attr-defined]
-                    session=http,
-                    fn_handle_streaming_chunk=fn_handle_streaming_chunk,
-                    additional_parameters=self._additional_parameters,
-                    id_above=None,
-                    page_number=self._page_number,
-                    ids=chunk,
-                ):
-                    yield result1
+        result: Optional[FhirGetResponse]
+        chunk_size: int = self._page_size or 1
+        for chunk in ListChunker.divide_into_chunks(id_list, chunk_size):
+            async for result1 in self._get_with_session_async(  # type: ignore[attr-defined]
+                fn_handle_streaming_chunk=fn_handle_streaming_chunk,
+                additional_parameters=self._additional_parameters,
+                id_above=None,
+                page_number=self._page_number,
+                ids=chunk,
+            ):
+                yield result1
 
     def graph(
         self,

--- a/helix_fhir_client_sdk/responses/fhir_client_protocol.py
+++ b/helix_fhir_client_sdk/responses/fhir_client_protocol.py
@@ -108,7 +108,6 @@ class FhirClientProtocol(Protocol):
     async def _get_with_session_async(
         self,
         *,
-        session: Optional[ClientSession],
         page_number: Optional[int],
         ids: Optional[List[str]],
         id_above: Optional[str],

--- a/helix_fhir_client_sdk/test/test_fhir_auth_mixin.py
+++ b/helix_fhir_client_sdk/test/test_fhir_auth_mixin.py
@@ -1,5 +1,5 @@
 import pytest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from aioresponses import aioresponses
 
 from helix_fhir_client_sdk.fhir_auth_mixin import FhirAuthMixin
@@ -21,7 +21,7 @@ async def test_get_auth_url_async_from_cache(fhir_auth_mixin: FhirAuthMixin) -> 
     fhir_auth_mixin._well_known_configuration_cache = {
         "test_host": WellKnownConfigurationCacheEntry(
             auth_url="https://auth.test/token",
-            last_updated_utc=datetime.utcnow() - timedelta(seconds=300),
+            last_updated_utc=datetime.now(UTC) - timedelta(seconds=300),
         )
     }
     fhir_auth_mixin._auth_wellknown_url = (

--- a/helix_fhir_client_sdk/utilities/retryable_aiohttp_client.py
+++ b/helix_fhir_client_sdk/utilities/retryable_aiohttp_client.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import datetime
+from datetime import datetime, UTC
 from typing import Optional, Dict, Any, List, Callable, Type, Union
 
 import async_timeout
@@ -233,7 +233,7 @@ class RetryableAioHttpClient:
         raise Exception("All retries failed")
 
     async def get(
-        self, *, url: str, headers: Optional[Dict[str, str]], **kwargs: Any
+        self, *, url: str, headers: Optional[Dict[str, str]] = None, **kwargs: Any
     ) -> RetryableAioHttpResponse:
         return await self.fetch(url=url, method="GET", headers=headers, **kwargs)
 
@@ -298,7 +298,7 @@ class RetryableAioHttpClient:
                 wait_till: datetime = datetime.strptime(
                     retry_after_text, "%a, %d %b %Y %H:%M:%S GMT"
                 )
-                while datetime.utcnow() < wait_till:
+                while datetime.now(UTC) < wait_till:
                     await asyncio.sleep(10)
         else:
             await asyncio.sleep(60)

--- a/helix_fhir_client_sdk/utilities/retryable_aiohttp_client.py
+++ b/helix_fhir_client_sdk/utilities/retryable_aiohttp_client.py
@@ -228,6 +228,18 @@ class RetryableAioHttpClient:
                             use_data_streaming=self.use_data_streaming,
                         )
                 await asyncio.sleep(self.backoff_factor * (2 ** (retry_attempts - 1)))
+            except Exception as e:
+                if self._throw_exception_on_error:
+                    raise
+                else:
+                    return RetryableAioHttpResponse(
+                        ok=False,
+                        status=500,
+                        response_headers={},
+                        response_text=str(e),
+                        content=None,
+                        use_data_streaming=self.use_data_streaming,
+                    )
 
         # Raise an exception if all retries fail
         raise Exception("All retries failed")

--- a/helix_fhir_client_sdk/validators/async_fhir_validator.py
+++ b/helix_fhir_client_sdk/validators/async_fhir_validator.py
@@ -42,8 +42,8 @@ class AsyncFhirValidator:
         async with RetryableAioHttpClient(
             fn_get_session=fn_get_session,
             use_data_streaming=False,
-        ) as http:
-            validation_response: RetryableAioHttpResponse = await http.post(
+        ) as client:
+            validation_response: RetryableAioHttpResponse = await client.post(
                 url=full_validation_uri.url,
                 data=json_data,
                 headers=headers,

--- a/tests/async/test_async_fhir_client_fetch_response_in_chunks.py
+++ b/tests/async/test_async_fhir_client_fetch_response_in_chunks.py
@@ -108,3 +108,5 @@ async def test_fhir_client_patient_list_async_streaming() -> None:
 
     print(response.responses)
     assert response.responses == response_text
+
+    assert response_text == ""

--- a/tests/async/test_async_fhir_client_fetch_response_in_chunks.py
+++ b/tests/async/test_async_fhir_client_fetch_response_in_chunks.py
@@ -108,5 +108,3 @@ async def test_fhir_client_patient_list_async_streaming() -> None:
 
     print(response.responses)
     assert response.responses == response_text
-
-    assert response_text == ""


### PR DESCRIPTION
Here are the main changes described in the PR:

- Replaced datetime.utcnow() with datetime.now(UTC) for better timezone handling
- Removed session parameter from several methods and replaced it with RetryableAioHttpClient
- Removed create_http_session() method calls in favor of using RetryableAioHttpClient
- Updated _get_with_session_async() method to remove session parameter
- Modified get_async() and get_streaming_async() methods to use _get_with_session_async() directly without creating a separate session
- Updated simulate_graph_async() method to remove session creation and use
- Modified _process_link_async() and _process_target_async() methods to remove session parameter
- Updated _get_resources_by_parameters_async() method to remove session parameter
- Modified get() method in RetryableAioHttpClient to make headers parameter optional
- Updated error handling in RetryableAioHttpClient to return a response with status 500 instead of raising an exception when throw_exception_on_error is False
- Various import adjustments and code cleanup

These changes appear to be focused on improving the handling of HTTP sessions, error management, and timezone consistency throughout the codebase.