### PR TITLE
Add missing unit tests for various modules

### DIFF
--- a/helix_fhir_client_sdk/filters/test/test_base_filter.py
+++ b/helix_fhir_client_sdk/filters/test/test_base_filter.py
@@ -1,0 +1,17 @@
+import unittest
+from helix_fhir_client_sdk.filters.base_filter import BaseFilter
+
+
+class TestBaseFilter(unittest.TestCase):
+    def test_base_filter_str(self):
+        base_filter = BaseFilter()
+        with self.assertRaises(NotImplementedError):
+            str(base_filter)
+
+    def test_base_filter_init(self):
+        base_filter = BaseFilter()
+        self.assertIsInstance(base_filter, BaseFilter)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/helix_fhir_client_sdk/filters/test/test_identifier_filter.py
+++ b/helix_fhir_client_sdk/filters/test/test_identifier_filter.py
@@ -1,0 +1,21 @@
+import unittest
+from helix_fhir_client_sdk.filters.identifier_filter import IdentifierFilter
+
+
+class TestIdentifierFilter(unittest.TestCase):
+    def test_identifier_filter_initialization(self):
+        system = "http://hl7.org/fhir/sid/us-npi"
+        value = "1487831681"
+        identifier_filter = IdentifierFilter(system=system, value=value)
+        self.assertEqual(identifier_filter.system, system)
+        self.assertEqual(identifier_filter.value, value)
+
+    def test_identifier_filter_str(self):
+        system = "http://hl7.org/fhir/sid/us-npi"
+        value = "1487831681"
+        identifier_filter = IdentifierFilter(system=system, value=value)
+        self.assertEqual(str(identifier_filter), f"identifier={system}|{value}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/helix_fhir_client_sdk/filters/test/test_last_updated_filter.py
+++ b/helix_fhir_client_sdk/filters/test/test_last_updated_filter.py
@@ -17,6 +17,25 @@ class TestLastUpdatedFilter(unittest.TestCase):
         last_updated_filter = LastUpdatedFilter(less_than=less_than, greater_than=greater_than)
         self.assertEqual(str(last_updated_filter), "_lastUpdated=lt2023-09-01&_lastUpdated=gt2023-08-01")
 
+    def test_last_updated_filter_str_only_less_than(self):
+        less_than = datetime(2023, 9, 1)
+        last_updated_filter = LastUpdatedFilter(less_than=less_than, greater_than=None)
+        self.assertEqual(str(last_updated_filter), "_lastUpdated=lt2023-09-01")
+
+    def test_last_updated_filter_str_only_greater_than(self):
+        greater_than = datetime(2023, 8, 1)
+        last_updated_filter = LastUpdatedFilter(less_than=None, greater_than=greater_than)
+        self.assertEqual(str(last_updated_filter), "_lastUpdated=gt2023-08-01")
+
+    def test_last_updated_filter_str_empty(self):
+        last_updated_filter = LastUpdatedFilter(less_than=None, greater_than=None)
+        self.assertEqual(str(last_updated_filter), "")
+
+    def test_last_updated_filter_init_none(self):
+        last_updated_filter = LastUpdatedFilter(less_than=None, greater_than=None)
+        self.assertIsNone(last_updated_filter.less_than)
+        self.assertIsNone(last_updated_filter.greater_than)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/helix_fhir_client_sdk/filters/test/test_last_updated_filter.py
+++ b/helix_fhir_client_sdk/filters/test/test_last_updated_filter.py
@@ -1,0 +1,22 @@
+import unittest
+from datetime import datetime
+from helix_fhir_client_sdk.filters.last_updated_filter import LastUpdatedFilter
+
+
+class TestLastUpdatedFilter(unittest.TestCase):
+    def test_last_updated_filter_initialization(self):
+        less_than = datetime(2023, 9, 1)
+        greater_than = datetime(2023, 8, 1)
+        last_updated_filter = LastUpdatedFilter(less_than=less_than, greater_than=greater_than)
+        self.assertEqual(last_updated_filter.less_than, less_than)
+        self.assertEqual(last_updated_filter.greater_than, greater_than)
+
+    def test_last_updated_filter_str(self):
+        less_than = datetime(2023, 9, 1)
+        greater_than = datetime(2023, 8, 1)
+        last_updated_filter = LastUpdatedFilter(less_than=less_than, greater_than=greater_than)
+        self.assertEqual(str(last_updated_filter), "_lastUpdated=lt2023-09-01&_lastUpdated=gt2023-08-01")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/helix_fhir_client_sdk/graph/test/test_graph_definition.py
+++ b/helix_fhir_client_sdk/graph/test/test_graph_definition.py
@@ -1,0 +1,81 @@
+import pytest
+from helix_fhir_client_sdk.graph.graph_definition import (
+    GraphDefinition,
+    GraphDefinitionLink,
+    GraphDefinitionTarget,
+)
+
+
+def test_graph_definition_initialization() -> None:
+    link = GraphDefinitionLink(
+        path="test_path",
+        target=[
+            GraphDefinitionTarget(type_="test_type", params="test_params", link=None)
+        ],
+    )
+    graph_definition = GraphDefinition(
+        id_="test_id", name="test_name", start="test_start", link=[link]
+    )
+
+    assert graph_definition.id_ == "test_id"
+    assert graph_definition.name == "test_name"
+    assert graph_definition.start == "test_start"
+    assert graph_definition.link == [link]
+
+
+def test_graph_definition_to_dict() -> None:
+    link = GraphDefinitionLink(
+        path="test_path",
+        target=[
+            GraphDefinitionTarget(type_="test_type", params="test_params", link=None)
+        ],
+    )
+    graph_definition = GraphDefinition(
+        id_="test_id", name="test_name", start="test_start", link=[link]
+    )
+
+    expected_dict = {
+        "resourceType": "GraphDefinition",
+        "id": "test_id",
+        "name": "test_name",
+        "status": "active",
+        "start": "test_start",
+        "link": [
+            {
+                "path": "test_path",
+                "target": [
+                    {"type": "test_type", "params": "test_params", "link": None}
+                ],
+            }
+        ],
+    }
+
+    assert graph_definition.to_dict() == expected_dict
+
+
+def test_graph_definition_from_dict() -> None:
+    input_dict = {
+        "id": "test_id",
+        "name": "test_name",
+        "start": "test_start",
+        "link": [
+            {
+                "path": "test_path",
+                "target": [
+                    {"type": "test_type", "params": "test_params", "link": None}
+                ],
+            }
+        ],
+    }
+
+    graph_definition = GraphDefinition.from_dict(input_dict)
+
+    assert graph_definition.id_ == "test_id"
+    assert graph_definition.name == "test_name"
+    assert graph_definition.start == "test_start"
+    assert len(graph_definition.link) == 1
+    assert graph_definition.link[0].path == "test_path"
+    assert len(graph_definition.link[0].target) == 1
+    assert graph_definition.link[0].target[0].type_ == "test_type"
+    assert graph_definition.link[0].target[0].params == "test_params"
+    assert graph_definition.link[0].target[0].link is None

--- a/helix_fhir_client_sdk/graph/test/test_graph_definition.py
+++ b/helix_fhir_client_sdk/graph/test/test_graph_definition.py
@@ -79,3 +79,114 @@ def test_graph_definition_from_dict() -> None:
     assert graph_definition.link[0].target[0].type_ == "test_type"
     assert graph_definition.link[0].target[0].params == "test_params"
     assert graph_definition.link[0].target[0].link is None
+
+
+def test_graph_definition_target_to_dict() -> None:
+    target = GraphDefinitionTarget(type_="test_type", params="test_params", link=None)
+    expected_dict = {"type": "test_type", "params": "test_params"}
+    assert target.to_dict() == expected_dict
+
+
+def test_graph_definition_target_from_dict() -> None:
+    input_dict = {"type": "test_type", "params": "test_params"}
+    target = GraphDefinitionTarget.from_dict(input_dict)
+    assert target.type_ == "test_type"
+    assert target.params == "test_params"
+    assert target.link is None
+
+
+def test_graph_definition_link_to_dict() -> None:
+    target = GraphDefinitionTarget(type_="test_type", params="test_params", link=None)
+    link = GraphDefinitionLink(path="test_path", target=[target])
+    expected_dict = {
+        "path": "test_path",
+        "target": [{"type": "test_type", "params": "test_params"}],
+    }
+    assert link.to_dict() == expected_dict
+
+
+def test_graph_definition_link_from_dict() -> None:
+    input_dict = {
+        "path": "test_path",
+        "target": [{"type": "test_type", "params": "test_params"}],
+    }
+    link = GraphDefinitionLink.from_dict(input_dict)
+    assert link.path == "test_path"
+    assert len(link.target) == 1
+    assert link.target[0].type_ == "test_type"
+    assert link.target[0].params == "test_params"
+    assert link.target[0].link is None
+
+
+def test_graph_definition_target_to_dict_with_link() -> None:
+    nested_link = GraphDefinitionLink(
+        path="nested_path",
+        target=[
+            GraphDefinitionTarget(type_="nested_type", params="nested_params", link=None)
+        ],
+    )
+    target = GraphDefinitionTarget(type_="test_type", params="test_params", link=[nested_link])
+    expected_dict = {
+        "type": "test_type",
+        "params": "test_params",
+        "link": [
+            {
+                "path": "nested_path",
+                "target": [
+                    {"type": "nested_type", "params": "nested_params"}
+                ],
+            }
+        ],
+    }
+    assert target.to_dict() == expected_dict
+
+
+def test_graph_definition_target_from_dict_with_link() -> None:
+    input_dict = {
+        "type": "test_type",
+        "params": "test_params",
+        "link": [
+            {
+                "path": "nested_path",
+                "target": [
+                    {"type": "nested_type", "params": "nested_params"}
+                ],
+            }
+        ],
+    }
+    target = GraphDefinitionTarget.from_dict(input_dict)
+    assert target.type_ == "test_type"
+    assert target.params == "test_params"
+    assert len(target.link) == 1
+    assert target.link[0].path == "nested_path"
+    assert len(target.link[0].target) == 1
+    assert target.link[0].target[0].type_ == "nested_type"
+    assert target.link[0].target[0].params == "nested_params"
+    assert target.link[0].target[0].link is None
+
+
+def test_graph_definition_link_to_dict_with_nested_target() -> None:
+    nested_target = GraphDefinitionTarget(type_="nested_type", params="nested_params", link=None)
+    link = GraphDefinitionLink(path="test_path", target=[nested_target])
+    expected_dict = {
+        "path": "test_path",
+        "target": [
+            {"type": "nested_type", "params": "nested_params"}
+        ],
+    }
+    assert link.to_dict() == expected_dict
+
+
+def test_graph_definition_link_from_dict_with_nested_target() -> None:
+    input_dict = {
+        "path": "test_path",
+        "target": [
+            {"type": "nested_type", "params": "nested_params"}
+        ],
+    }
+    link = GraphDefinitionLink.from_dict(input_dict)
+    assert link.path == "test_path"
+    assert len(link.target) == 1
+    assert link.target[0].type_ == "nested_type"
+    assert link.target[0].params == "nested_params"
+    assert link.target[0].link is None

--- a/helix_fhir_client_sdk/validators/test/test_async_fhir_validator.py
+++ b/helix_fhir_client_sdk/validators/test/test_async_fhir_validator.py
@@ -90,3 +90,85 @@ async def test_validate_fhir_resource_server_error() -> None:
                     validation_server_url=validation_server_url,
                     access_token=access_token,
                 )
+
+
+@pytest.mark.asyncio
+async def test_validate_fhir_resource_with_valid_input() -> None:
+    async def mock_get_session() -> ClientSession:
+        return ClientSession()
+
+    json_data = '{"resourceType": "Patient", "id": "123"}'
+    resource_name = "Patient"
+    validation_server_url = "http://validation-server.com"
+    access_token = "test-token"
+
+    async with aiohttp.ClientSession() as session:
+        with aioresponses() as m:
+            m.post(
+                "http://validation-server.com/Patient/$validate",
+                status=200,
+                payload={"issue": []},
+                headers={"X-Request-ID": "test-request-id"},
+            )
+
+            await AsyncFhirValidator.validate_fhir_resource(
+                fn_get_session=lambda: session,
+                json_data=json_data,
+                resource_name=resource_name,
+                validation_server_url=validation_server_url,
+                access_token=access_token,
+            )
+
+
+@pytest.mark.asyncio
+async def test_validate_fhir_resource_with_validation_error() -> None:
+    json_data = '{"resourceType": "Patient", "id": "123"}'
+    resource_name = "Patient"
+    validation_server_url = "http://validation-server.com"
+    access_token = "test-token"
+
+    async with aiohttp.ClientSession() as session:
+        with aioresponses() as m:
+            m.post(
+                "http://validation-server.com/Patient/$validate",
+                status=200,
+                payload={
+                    "issue": [{"severity": "error", "details": {"text": "Validation error"}}]
+                },
+                headers={"X-Request-ID": "test-request-id"},
+            )
+
+            with pytest.raises(FhirValidationException):
+                await AsyncFhirValidator.validate_fhir_resource(
+                    fn_get_session=lambda: session,
+                    json_data=json_data,
+                    resource_name=resource_name,
+                    validation_server_url=validation_server_url,
+                    access_token=access_token,
+                )
+
+
+@pytest.mark.asyncio
+async def test_validate_fhir_resource_with_server_error() -> None:
+    json_data = '{"resourceType": "Patient", "id": "123"}'
+    resource_name = "Patient"
+    validation_server_url = "http://validation-server.com"
+    access_token = "test-token"
+
+    async with aiohttp.ClientSession() as session:
+        with aioresponses() as m:
+            m.post(
+                "http://validation-server.com/Patient/$validate",
+                status=500,
+                body="Internal Server Error",
+                headers={"X-Request-ID": "test-request-id"},
+            )
+
+            with pytest.raises(FhirValidationException):
+                await AsyncFhirValidator.validate_fhir_resource(
+                    fn_get_session=lambda: session,
+                    json_data=json_data,
+                    resource_name=resource_name,
+                    validation_server_url=validation_server_url,
+                    access_token=access_token,
+                )


### PR DESCRIPTION
Add missing unit tests for various modules in the project.

* **Validators:**
  - Add tests for `validate_fhir_resource` method with valid input, validation error, and server error in `helix_fhir_client_sdk/validators/test/test_async_fhir_validator.py`.

* **Graph Definition:**
  - Add tests for `GraphDefinition` class initialization, `to_dict` method, and `from_dict` method in `helix_fhir_client_sdk/graph/test/test_graph_definition.py`.

* **Filters:**
  - Add tests for `BaseFilter` class `__str__` method and `__init__` method in `helix_fhir_client_sdk/filters/test/test_base_filter.py`.
  - Add tests for `IdentifierFilter` class initialization and `__str__` method in `helix_fhir_client_sdk/filters/test/test_identifier_filter.py`.
  - Add tests for `LastUpdatedFilter` class initialization and `__str__` method in `helix_fhir_client_sdk/filters/test/test_last_updated_filter.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/icanbwell/helix.fhir.client.sdk/pull/147?shareId=6967a6b8-180a-404f-8434-d929c4016dc1).