### PR TITLE
chore(deps): exclude uv packages published in the last 2 days

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dev = [
 ]
 
 [tool.uv]
+exclude-newer = "2 days"
 constraint-dependencies = ["msgpack>=1.2.1"]
 
 [tool.ruff]


### PR DESCRIPTION
## Summary
- Adds uv's `exclude-newer` setting so the resolver skips package versions published in the last 2 days, avoiding installs failing/hanging when Aikido Endpoint Protection flags brand-new releases as a supply-chain risk.

**Note:** `uv.lock` was *not* regenerated here. `make uv.lock` runs `docker compose run`, which brings up this repo's full dev stack (mongo/keycloak/mock-server/fhir) as a dependency, and port 27017 was already bound by an unrelated stack in the environment this PR was authored in. Please run `make uv.lock` and push the result before merging (or let CI/a maintainer do it) so the lock reflects the new cutoff.

Background: https://icanbwell.atlassian.net/wiki/x/RgAnhQE

## Test plan
- [ ] `make uv.lock` re-run and committed
- [ ] CI passes